### PR TITLE
feature: add WB/LB path prefix to bracket cross-references

### DIFF
--- a/components/game-server-nodes/GameServerNodeRow.vue
+++ b/components/game-server-nodes/GameServerNodeRow.vue
@@ -337,21 +337,22 @@ const isSectionExpanded = (section: string) => {
           <FiveStackToolTip>
             <template #trigger>
               <div class="cursor-pointer">
-                <HardDrive
-                  class="h-4 w-4"
-                  :class="diskColorClass"
-                />
+                <HardDrive class="h-4 w-4" :class="diskColorClass" />
               </div>
             </template>
             <div class="space-y-2">
               <div class="font-medium">{{ $t("game_server.disk_usage") }}</div>
               <div class="flex items-center justify-between gap-4 text-xs">
-                <span class="text-muted-foreground">{{ $t("game_server.disk_used") }}:</span>
-                <span>{{ gameServerNode.disk_used_percent ?? '-' }}%</span>
+                <span class="text-muted-foreground"
+                  >{{ $t("game_server.disk_used") }}:</span
+                >
+                <span>{{ gameServerNode.disk_used_percent ?? "-" }}%</span>
               </div>
               <div class="flex items-center justify-between gap-4 text-xs">
-                <span class="text-muted-foreground">{{ $t("game_server.disk_available") }}:</span>
-                <span>{{ gameServerNode.disk_available_gb ?? '-' }} GB</span>
+                <span class="text-muted-foreground"
+                  >{{ $t("game_server.disk_available") }}:</span
+                >
+                <span>{{ gameServerNode.disk_available_gb ?? "-" }} GB</span>
               </div>
             </div>
           </FiveStackToolTip>
@@ -1251,11 +1252,11 @@ const isSectionExpanded = (section: string) => {
                     <span class="text-muted-foreground">GPU</span>
                   </div>
                   <div class="flex items-center gap-1">
-                    <HardDrive
-                      class="h-3 w-3"
-                      :class="diskColorClass"
-                    />
-                    <span class="text-muted-foreground">Disk: {{ gameServerNode.disk_used_percent ?? '-' }}%</span>
+                    <HardDrive class="h-3 w-3" :class="diskColorClass" />
+                    <span class="text-muted-foreground"
+                      >Disk:
+                      {{ gameServerNode.disk_used_percent ?? "-" }}%</span
+                    >
                   </div>
                 </div>
               </div>
@@ -2262,8 +2263,12 @@ export default defineComponent({
     diskColorClass() {
       const percent = this.gameServerNode.disk_used_percent;
       if (percent == null) return "text-muted-foreground";
-      const criticalRaw = parseInt(this.settings.find((s) => s.name === "disk_critical_percent")?.value);
-      const warningRaw = parseInt(this.settings.find((s) => s.name === "disk_warning_percent")?.value);
+      const criticalRaw = parseInt(
+        this.settings.find((s) => s.name === "disk_critical_percent")?.value,
+      );
+      const warningRaw = parseInt(
+        this.settings.find((s) => s.name === "disk_warning_percent")?.value,
+      );
       const critical = Number.isNaN(criticalRaw) ? 90 : criticalRaw;
       const warning = Number.isNaN(warningRaw) ? 75 : warningRaw;
       if (critical > 0 && percent >= critical) return "text-red-500";

--- a/components/hub/NotificationsPanel.vue
+++ b/components/hub/NotificationsPanel.vue
@@ -120,7 +120,9 @@ import Empty from "~/components/ui/empty/Empty.vue";
                   size="sm"
                   variant="outline"
                   @click="dismissNotification(notification.id)"
-                  v-if="!notification.is_read && notification.deletable !== false"
+                  v-if="
+                    !notification.is_read && notification.deletable !== false
+                  "
                 >
                   {{ $t("layouts.notifications.dismiss") }}
                 </Button>
@@ -244,7 +246,10 @@ export default {
       await this.$apollo.mutate({
         mutation: generateMutation({
           update_notifications: [
-            { where: { is_read: { _eq: false }, deletable: { _neq: false } }, _set: { is_read: true } },
+            {
+              where: { is_read: { _eq: false }, deletable: { _neq: false } },
+              _set: { is_read: true },
+            },
             { __typename: true },
           ],
         }),

--- a/components/match/ScheduleMatch.vue
+++ b/components/match/ScheduleMatch.vue
@@ -110,7 +110,11 @@ import { generateMutation } from "~/graphql/graphqlGen";
 import { useForm } from "vee-validate";
 import * as z from "zod";
 import { toTypedSchema } from "@vee-validate/zod";
-import { fromDate, toCalendarDate, getLocalTimeZone } from "@internationalized/date";
+import {
+  fromDate,
+  toCalendarDate,
+  getLocalTimeZone,
+} from "@internationalized/date";
 
 export default {
   props: {
@@ -155,7 +159,9 @@ export default {
       handler(match) {
         if (match?.scheduled_at) {
           const startDate = new Date(match.scheduled_at);
-          this.startDate = toCalendarDate(fromDate(startDate, getLocalTimeZone()));
+          this.startDate = toCalendarDate(
+            fromDate(startDate, getLocalTimeZone()),
+          );
           this.startTime = `${startDate.getHours().toString().padStart(2, "0")}:${startDate.getMinutes().toString().padStart(2, "0")}`;
           this.form.setValues({
             scheduled_at: startDate.toISOString(),
@@ -173,7 +179,9 @@ export default {
         return;
       }
       this.form.setValues({
-        scheduled_at: new Date(`${this.startDate} ${this.startTime}`).toISOString(),
+        scheduled_at: new Date(
+          `${this.startDate} ${this.startTime}`,
+        ).toISOString(),
       });
     },
     async scheduleMatch() {

--- a/components/tournament/BracketScheduleDialog.vue
+++ b/components/tournament/BracketScheduleDialog.vue
@@ -175,7 +175,9 @@ export default {
     },
     async saveSchedule() {
       if (!this.bracket || !this.startDate || !this.startTime) return;
-      const scheduled_at = new Date(`${this.startDate} ${this.startTime}`).toISOString();
+      const scheduled_at = new Date(
+        `${this.startDate} ${this.startTime}`,
+      ).toISOString();
       if (new Date(scheduled_at) <= new Date()) {
         toast({
           title: this.$t("tournament.bracket.past_time_error"),

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -202,6 +202,26 @@ const getWbFeedForSlot = (
   return undefined;
 };
 
+/**
+ * Get the feeding bracket for a given team slot (1 or 2), regardless of path.
+ * Used for text placeholders like "Winner R1M1" or "Loser WB R2M2".
+ */
+const getFeedForSlot = (
+  bracket: Bracket,
+  slot: 1 | 2,
+): FeedingBracket | undefined => {
+  const feeds = bracket.feeding_brackets || [];
+  if (feeds.length === 0) return undefined;
+
+  if (feeds.length >= 2) return feeds[slot - 1];
+
+  // Single feed: assign to whichever slot is empty
+  if (slot === 1 && !bracket.team_1) return feeds[0];
+  if (slot === 2 && bracket.team_1) return feeds[0];
+
+  return undefined;
+};
+
 const isShowingDestinations = (bracket: Bracket) => {
   return bracket.path === "WB" && !bracket.match;
 };
@@ -396,17 +416,12 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                         }}</span
                       >
                     </span>
-                    <!-- LB: show only WB feeds in Team 1/2 -->
-                    <template
-                      v-if="
-                        bracket.path === 'LB' &&
-                        getWbFeedForSlot(bracket, 1)
-                      "
-                    >
+                    <!-- Show where this team will come from -->
+                    <template v-if="getFeedForSlot(bracket, 1)">
                       {{
                         formatFeedingText(
                           bracket,
-                          getWbFeedForSlot(bracket, 1),
+                          getFeedForSlot(bracket, 1),
                         )
                       }}
                     </template>
@@ -459,17 +474,12 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                         }}</span
                       >
                     </span>
-                    <!-- LB: show only WB feeds in Team 1/2 -->
-                    <template
-                      v-if="
-                        bracket.path === 'LB' &&
-                        getWbFeedForSlot(bracket, 2)
-                      "
-                    >
+                    <!-- Show where this team will come from -->
+                    <template v-if="getFeedForSlot(bracket, 2)">
                       {{
                         formatFeedingText(
                           bracket,
-                          getWbFeedForSlot(bracket, 2),
+                          getFeedForSlot(bracket, 2),
                         )
                       }}
                     </template>

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -257,6 +257,44 @@ const formatDestinationText = (
 const isLbFeedingToWb = (bracket: Bracket) => {
   return bracket.path === "LB" && bracket.parent_bracket?.path === "WB";
 };
+
+/**
+ * Bracket viewers render one group at a time; SVG lines only connect matches in
+ * the same DOM. When source and target differ by group (e.g. WB → LB), show a
+ * hint instead of duplicating what a line already conveys.
+ */
+const isSameViewerGroup = (
+  a: number | undefined,
+  b: number | undefined,
+): boolean => a === b;
+
+/**
+ * Show feed-in text only when the feeder is not in the same viewer as this
+ * match (no drawn connector), or the graph edge is missing from feed metadata.
+ * Swiss layout does not draw connector lines, so always show when a feed exists.
+ */
+const shouldShowFeedInHint = (
+  bracket: Bracket,
+  feeding: FeedingBracket | undefined,
+): boolean => {
+  if (!feeding) return false;
+  if (props.stage.type === e_tournament_stage_types_enum.Swiss) {
+    return true;
+  }
+  const hasGraphEdge =
+    feeding.parent_bracket_id === bracket.id ||
+    feeding.loser_parent_bracket_id === bracket.id;
+  if (!hasGraphEdge) return true;
+  return !isSameViewerGroup(feeding.group, bracket.group);
+};
+
+const shouldShowCrossBracketDestination = (
+  bracket: Bracket,
+  dest?: { id?: string; group?: number },
+): boolean => {
+  if (!dest?.id) return false;
+  return !isSameViewerGroup(dest.group, bracket.group);
+};
 </script>
 
 <template>
@@ -392,15 +430,24 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                         }}</span
                       >
                     </span>
-                    <!-- Show where this team will come from -->
-                    <template v-if="getFeedForSlot(bracket, 1)">
+                    <!-- Cross-view feed only (no connector line in this bracket column) -->
+                    <Badge
+                      v-if="
+                        shouldShowFeedInHint(
+                          bracket,
+                          getFeedForSlot(bracket, 1),
+                        )
+                      "
+                      variant="outline"
+                      class="shrink-0 border-amber-500/35 bg-amber-950/25 text-amber-200/90 font-normal"
+                    >
                       {{
                         formatFeedingText(
                           bracket,
                           getFeedForSlot(bracket, 1),
                         )
                       }}
-                    </template>
+                    </Badge>
                   </template>
                   {{ getTeamName(bracket.team_1) }}
                 </span>
@@ -450,15 +497,23 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                         }}</span
                       >
                     </span>
-                    <!-- Show where this team will come from -->
-                    <template v-if="getFeedForSlot(bracket, 2)">
+                    <Badge
+                      v-if="
+                        shouldShowFeedInHint(
+                          bracket,
+                          getFeedForSlot(bracket, 2),
+                        )
+                      "
+                      variant="outline"
+                      class="shrink-0 border-amber-500/35 bg-amber-950/25 text-amber-200/90 font-normal"
+                    >
                       {{
                         formatFeedingText(
                           bracket,
                           getFeedForSlot(bracket, 2),
                         )
                       }}
-                    </template>
+                    </Badge>
                   </template>
                 </span>
                 {{ getTeamName(bracket.team_2) }}
@@ -471,8 +526,17 @@ const isLbFeedingToWb = (bracket: Bracket) => {
       <template
         v-if="stage.type === e_tournament_stage_types_enum.DoubleElimination"
       >
-        <div v-if="isLbFeedingToWb(bracket)" class="text-center">
-          <div class="text-xs text-green-400 font-medium">
+        <div
+          v-if="
+            isLbFeedingToWb(bracket) &&
+            shouldShowCrossBracketDestination(bracket, bracket.parent_bracket)
+          "
+          class="flex justify-center"
+        >
+          <Badge
+            variant="outline"
+            class="border-emerald-500/40 bg-emerald-950/25 text-emerald-300 font-normal"
+          >
             {{
               formatDestinationText(
                 "winner",
@@ -480,10 +544,20 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                 bracket.parent_bracket?.path,
               )
             }}
-          </div>
+          </Badge>
         </div>
-        <div v-if="bracket.loser_bracket && !bracket.bye" class="text-center">
-          <div class="text-xs text-red-400 font-medium">
+        <div
+          v-if="
+            bracket.loser_bracket &&
+            !bracket.bye &&
+            shouldShowCrossBracketDestination(bracket, bracket.loser_bracket)
+          "
+          class="flex justify-center"
+        >
+          <Badge
+            variant="outline"
+            class="border-red-500/45 bg-red-950/30 text-red-300 font-normal"
+          >
             {{
               formatDestinationText(
                 "loser",
@@ -491,7 +565,7 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                 bracket.loser_bracket.path,
               )
             }}
-          </div>
+          </Badge>
         </div>
       </template>
       <div v-if="isThirdPlaceMatch(bracket)" class="text-center">

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -172,33 +172,24 @@ const handleClick = (event: MouseEvent, bracket: Bracket) => {
  * assign_team_to_bracket_slot: loser drops first, then winner
  * feeds, then by round and match_number within each group.
  */
-const getFeedForSlot = (
-  bracket: Bracket,
-  slot: 1 | 2,
-): FeedingBracket | undefined => {
+const getSortedFeeds = (bracket: Bracket): FeedingBracket[] => {
   const feeds = bracket.feeding_brackets || [];
-  if (feeds.length === 0) return undefined;
-  const sorted = [...feeds].sort((a, b) => {
+  if (feeds.length === 0) return [];
+  return [...feeds].sort((a, b) => {
     const aLoser = a.loser_parent_bracket_id === bracket.id ? 0 : 1;
     const bLoser = b.loser_parent_bracket_id === bracket.id ? 0 : 1;
     if (aLoser !== bLoser) return aLoser - bLoser;
     if ((a.round ?? 0) !== (b.round ?? 0)) return (a.round ?? 0) - (b.round ?? 0);
     return (a.match_number ?? 0) - (b.match_number ?? 0);
   });
-  return sorted[slot - 1];
 };
 
-/**
- * Get the WB feeding bracket for a given team slot.
- * Filters feeds to only those coming from WB (loser drops into LB).
- */
-const getWbFeedForSlot = (
+const getFeedForSlot = (
   bracket: Bracket,
   slot: 1 | 2,
 ): FeedingBracket | undefined => {
-  const feed = getFeedForSlot(bracket, slot);
-  if (feed && feed.path === "WB") return feed;
-  return undefined;
+  const sorted = getSortedFeeds(bracket);
+  return sorted[slot - 1];
 };
 
 const formatRoundRef = (
@@ -212,27 +203,14 @@ const formatRoundRef = (
     : t(`tournament.match.${pathPrefix}round_ref`, { round });
 };
 
-const formatRoundRefCompact = (
-  round: number,
-  match_number?: number,
-  path?: string,
-) => {
-  const pathPrefix = path === "WB" ? "wb_" : path === "LB" ? "lb_" : "";
-  return match_number
-    ? t(`tournament.match.${pathPrefix}round_match_compact`, {
-        round,
-        match: match_number,
-      })
-    : t(`tournament.match.${pathPrefix}round_compact`, { round });
-};
-
+/** Same pattern as formatDestinationText: "Winner → …" / "Loser → …" + full round ref. */
 const formatFeedingText = (bracket: Bracket, feeding?: FeedingBracket) => {
   if (!feeding) return "";
   const isLoserDrop = feeding.loser_parent_bracket_id === bracket.id;
   const prefix = isLoserDrop
-    ? t("tournament.match.loser")
-    : t("tournament.match.winner");
-  const roundRef = formatRoundRefCompact(
+    ? t("tournament.match.loser_arrow")
+    : t("tournament.match.winner_arrow");
+  const roundRef = formatRoundRef(
     feeding.round,
     feeding.match_number,
     feeding.path,
@@ -286,6 +264,46 @@ const shouldShowFeedInHint = (
     feeding.loser_parent_bracket_id === bracket.id;
   if (!hasGraphEdge) return true;
   return !isSameViewerGroup(feeding.group, bracket.group);
+};
+
+/**
+ * Map sorted feeds to top/bottom rows. Top = same-view / incoming line; bottom
+ * = cross-view amber hint when only one feed needs that hint. If two feeds and
+ * exactly one needs a cross-view label, put the same-view feed on top and the
+ * hint on the bottom.
+ */
+const getFeedForDisplayRow = (
+  bracket: Bracket,
+  row: 1 | 2,
+): FeedingBracket | undefined => {
+  const sorted = getSortedFeeds(bracket);
+  if (sorted.length === 0) return undefined;
+
+  const needsHint = (f: FeedingBracket) => shouldShowFeedInHint(bracket, f);
+  const hintFeeds = sorted.filter(needsHint);
+  const noHintFeeds = sorted.filter((f) => !needsHint(f));
+
+  if (sorted.length === 2 && hintFeeds.length === 1 && noHintFeeds.length === 1) {
+    return row === 1 ? noHintFeeds[0] : hintFeeds[0];
+  }
+
+  if (sorted.length === 1) {
+    if (needsHint(sorted[0])) {
+      return row === 2 ? sorted[0] : undefined;
+    }
+    return row === 1 ? sorted[0] : undefined;
+  }
+
+  return sorted[row - 1];
+};
+
+const getWbFeedForDisplayRow = (
+  bracket: Bracket,
+  row: 1 | 2,
+): FeedingBracket | undefined => {
+  const feed = getFeedForDisplayRow(bracket, row);
+  if (feed && feed.path === "WB") return feed;
+  return undefined;
 };
 
 const shouldShowCrossBracketDestination = (
@@ -416,17 +434,17 @@ const shouldShowCrossBracketDestination = (
                     <span
                       v-if="
                         bracket.path !== 'WB' &&
-                        (getWbFeedForSlot(bracket, 1)?.team_1_seed ||
-                          getWbFeedForSlot(bracket, 1)?.team_2_seed)
+                        (getWbFeedForDisplayRow(bracket, 1)?.team_1_seed ||
+                          getWbFeedForDisplayRow(bracket, 1)?.team_2_seed)
                       "
                       class="text-xs text-gray-200/70 bg-gray-700/60 border border-gray-800 rounded px-1.5 py-0.5"
                     >
                       #{{
-                        getWbFeedForSlot(bracket, 1)?.team_1_seed || "?"
+                        getWbFeedForDisplayRow(bracket, 1)?.team_1_seed || "?"
                       }}<span
-                        v-if="getWbFeedForSlot(bracket, 1)?.team_2_seed"
+                        v-if="getWbFeedForDisplayRow(bracket, 1)?.team_2_seed"
                         >/{{
-                          getWbFeedForSlot(bracket, 1)?.team_2_seed
+                          getWbFeedForDisplayRow(bracket, 1)?.team_2_seed
                         }}</span
                       >
                     </span>
@@ -435,16 +453,16 @@ const shouldShowCrossBracketDestination = (
                       v-if="
                         shouldShowFeedInHint(
                           bracket,
-                          getFeedForSlot(bracket, 1),
+                          getFeedForDisplayRow(bracket, 1),
                         )
                       "
                       variant="outline"
-                      class="shrink-0 border-amber-500/35 bg-amber-950/25 text-amber-200/90 font-normal"
+                      class="min-w-0 shrink border-amber-500/50 bg-amber-950/35 text-amber-200 font-normal px-2.5 py-1"
                     >
                       {{
                         formatFeedingText(
                           bracket,
-                          getFeedForSlot(bracket, 1),
+                          getFeedForDisplayRow(bracket, 1),
                         )
                       }}
                     </Badge>
@@ -483,17 +501,17 @@ const shouldShowCrossBracketDestination = (
                     <span
                       v-if="
                         bracket.path === 'LB' &&
-                        (getWbFeedForSlot(bracket, 2)?.team_1_seed ||
-                          getWbFeedForSlot(bracket, 2)?.team_2_seed)
+                        (getWbFeedForDisplayRow(bracket, 2)?.team_1_seed ||
+                          getWbFeedForDisplayRow(bracket, 2)?.team_2_seed)
                       "
                       class="text-xs text-gray-200/70 bg-gray-700/60 border border-gray-800 rounded px-1.5 py-0.5"
                     >
                       #{{
-                        getWbFeedForSlot(bracket, 2)?.team_1_seed || "?"
+                        getWbFeedForDisplayRow(bracket, 2)?.team_1_seed || "?"
                       }}<span
-                        v-if="getWbFeedForSlot(bracket, 2)?.team_2_seed"
+                        v-if="getWbFeedForDisplayRow(bracket, 2)?.team_2_seed"
                         >/{{
-                          getWbFeedForSlot(bracket, 2)?.team_2_seed
+                          getWbFeedForDisplayRow(bracket, 2)?.team_2_seed
                         }}</span
                       >
                     </span>
@@ -501,16 +519,16 @@ const shouldShowCrossBracketDestination = (
                       v-if="
                         shouldShowFeedInHint(
                           bracket,
-                          getFeedForSlot(bracket, 2),
+                          getFeedForDisplayRow(bracket, 2),
                         )
                       "
                       variant="outline"
-                      class="shrink-0 border-amber-500/35 bg-amber-950/25 text-amber-200/90 font-normal"
+                      class="min-w-0 shrink border-amber-500/50 bg-amber-950/35 text-amber-200 font-normal px-2.5 py-1"
                     >
                       {{
                         formatFeedingText(
                           bracket,
-                          getFeedForSlot(bracket, 2),
+                          getFeedForDisplayRow(bracket, 2),
                         )
                       }}
                     </Badge>

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -195,31 +195,40 @@ const getFeedPrefix = (currentPath?: string, feedingPath?: string) => {
     : t("tournament.match.loser_of");
 };
 
+const formatRoundRef = (
+  round: number,
+  match_number?: number,
+  path?: string,
+) => {
+  const pathPrefix = path === "WB" ? "wb_" : path === "LB" ? "lb_" : "";
+  return match_number
+    ? t(`tournament.match.${pathPrefix}round_match_ref`, { round, match: match_number })
+    : t(`tournament.match.${pathPrefix}round_ref`, { round });
+};
+
 const formatFeedingText = (bracket: Bracket, feeding?: FeedingBracket) => {
   if (!feeding) return "";
   const prefix = getFeedPrefix(bracket.path, feeding.path);
-  const roundMatch = feeding.match_number
-    ? t("tournament.match.round_match_ref", {
-        round: feeding.round,
-        match: feeding.match_number,
-      })
-    : t("tournament.match.round_ref", { round: feeding.round });
+  const roundMatch = formatRoundRef(
+    feeding.round,
+    feeding.match_number,
+    feeding.path !== bracket.path ? feeding.path : undefined,
+  );
   return `${prefix} ${roundMatch}`.trim();
 };
 
 const formatDestinationText = (
   type: "winner" | "loser",
-  dest?: { round: number; match_number?: number },
+  dest?: { round: number; match_number?: number; path?: string },
+  path?: string,
 ) => {
   if (!dest) return "";
   const prefix =
     type === "winner"
       ? t("tournament.match.winner_arrow")
       : t("tournament.match.loser_arrow");
-  if (dest.match_number) {
-    return `${prefix} ${t("tournament.match.round_match_ref", { round: dest.round, match: dest.match_number })}`;
-  }
-  return `${prefix} ${t("tournament.match.round_ref", { round: dest.round })}`;
+  const roundMatch = formatRoundRef(dest.round, dest.match_number, path);
+  return `${prefix} ${roundMatch}`;
 };
 
 const isLbFeedingToWb = (bracket: Bracket) => {
@@ -406,16 +415,6 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                       }}</span
                     >
                   </span>
-                  <!-- WB: show where loser goes -->
-                  <template
-                    v-if="bracket.path === 'WB' && bracket.loser_bracket"
-                  >
-                    <span class="text-red-400">
-                      {{
-                        formatDestinationText("loser", bracket.loser_bracket)
-                      }}
-                    </span>
-                  </template>
                   <!-- LB: show only WB feeds in Team 1/2 -->
                   <template
                     v-else-if="
@@ -443,49 +442,24 @@ const isLbFeedingToWb = (bracket: Bracket) => {
       >
         <div v-if="isLbFeedingToWb(bracket)" class="text-center">
           <div class="text-xs text-green-400 font-medium">
-            <span class="inline-flex items-center gap-1">
-              <span>{{ $t("tournament.match.winner_bracket_arrow") }}</span>
-              <span v-if="bracket.parent_bracket?.match_number">
-                {{
-                  $t("tournament.match.round_match_ref", {
-                    round: bracket.parent_bracket.round,
-                    match: bracket.parent_bracket.match_number,
-                  })
-                }}
-              </span>
-              <span v-else>
-                {{
-                  $t("tournament.match.round_ref", {
-                    round: bracket.parent_bracket?.round,
-                  })
-                }}
-              </span>
-            </span>
+            {{
+              formatDestinationText(
+                "winner",
+                bracket.parent_bracket,
+                bracket.parent_bracket?.path,
+              )
+            }}
           </div>
         </div>
-        <div
-          v-if="bracket.loser_bracket && !isShowingDestinations(bracket)"
-          class="text-center"
-        >
+        <div v-if="bracket.loser_bracket" class="text-center">
           <div class="text-xs text-red-400 font-medium">
-            <span class="inline-flex items-center gap-1">
-              <span>{{ $t("tournament.match.loser_arrow") }}</span>
-              <span v-if="bracket.loser_bracket.match_number">
-                {{
-                  $t("tournament.match.round_match_ref", {
-                    round: bracket.loser_bracket.round,
-                    match: bracket.loser_bracket.match_number,
-                  })
-                }}
-              </span>
-              <span v-else>
-                {{
-                  $t("tournament.match.round_ref", {
-                    round: bracket.loser_bracket.round,
-                  })
-                }}
-              </span>
-            </span>
+            {{
+              formatDestinationText(
+                "loser",
+                bracket.loser_bracket,
+                bracket.loser_bracket.path,
+              )
+            }}
           </div>
         </div>
       </template>

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -166,45 +166,11 @@ const handleClick = (event: MouseEvent, bracket: Bracket) => {
   }
 };
 
-const getFeedingBracketsByPath = (bracket: Bracket, path: "WB" | "LB") => {
-  return (bracket.feeding_brackets || []).filter((b) => b.path === path);
-};
-
-const getFeedingBracketAt = (
-  bracket: Bracket,
-  path: "WB" | "LB",
-  index: number,
-) => {
-  return getFeedingBracketsByPath(bracket, path)[index];
-};
-
 /**
- * Get the WB feeding bracket for a given team slot (1 or 2).
- * In LB R1, there are two WB feeds mapped 1:1 to slots.
- * In later LB rounds (R2, R4, etc.), there's only one WB feed.
- * That single feed should appear in whichever slot doesn't already
- * have a resolved team (the other slot is filled by an LB feed).
- */
-const getWbFeedForSlot = (
-  bracket: Bracket,
-  slot: 1 | 2,
-): FeedingBracket | undefined => {
-  const wbFeeds = getFeedingBracketsByPath(bracket, "WB");
-  if (wbFeeds.length === 0) return undefined;
-
-  // Two or more WB feeds (e.g. LB R1): direct index mapping
-  if (wbFeeds.length >= 2) return wbFeeds[slot - 1];
-
-  // Single WB feed: show in slot 1 if team_1 is empty, slot 2 if team_1 is filled
-  if (slot === 1 && !bracket.team_1) return wbFeeds[0];
-  if (slot === 2 && bracket.team_1) return wbFeeds[0];
-
-  return undefined;
-};
-
-/**
- * Get the feeding bracket for a given team slot (1 or 2), regardless of path.
- * Used for text placeholders like "Winner R1M1" or "Loser WB R2M2".
+ * Get the feeding bracket for a given team slot (1 or 2).
+ * Uses DB relationships: feeds whose parent_bracket_id points here
+ * are winner feeds, feeds whose loser_parent_bracket_id points here
+ * are loser drops. Slot 1 gets the first feed, slot 2 gets the second.
  */
 const getFeedForSlot = (
   bracket: Bracket,
@@ -212,31 +178,20 @@ const getFeedForSlot = (
 ): FeedingBracket | undefined => {
   const feeds = bracket.feeding_brackets || [];
   if (feeds.length === 0) return undefined;
+  return feeds[slot - 1];
+};
 
-  if (feeds.length >= 2) return feeds[slot - 1];
-
-  // Single feed: assign to whichever slot is empty
-  if (slot === 1 && !bracket.team_1) return feeds[0];
-  if (slot === 2 && bracket.team_1) return feeds[0];
-
+/**
+ * Get the WB feeding bracket for a given team slot.
+ * Filters feeds to only those coming from WB (loser drops into LB).
+ */
+const getWbFeedForSlot = (
+  bracket: Bracket,
+  slot: 1 | 2,
+): FeedingBracket | undefined => {
+  const feed = getFeedForSlot(bracket, slot);
+  if (feed && feed.path === "WB") return feed;
   return undefined;
-};
-
-const isShowingDestinations = (bracket: Bracket) => {
-  return bracket.path === "WB" && !bracket.match;
-};
-
-const getBracketLabel = (path?: string) => {
-  if (path === "WB") return t("tournament.match.upper_bracket");
-  if (path === "LB") return t("tournament.match.lower_bracket");
-  return "";
-};
-
-const getFeedPrefix = (currentPath?: string, feedingPath?: string) => {
-  if (!currentPath || !feedingPath) return t("tournament.match.winner_of");
-  return currentPath === feedingPath
-    ? t("tournament.match.winner_of")
-    : t("tournament.match.loser_of");
 };
 
 const formatRoundRef = (
@@ -266,14 +221,14 @@ const formatRoundRefCompact = (
 
 const formatFeedingText = (bracket: Bracket, feeding?: FeedingBracket) => {
   if (!feeding) return "";
-  const prefix =
-    bracket.path === feeding.path
-      ? t("tournament.match.winner")
-      : t("tournament.match.loser");
+  const isLoserDrop = feeding.loser_parent_bracket_id === bracket.id;
+  const prefix = isLoserDrop
+    ? t("tournament.match.loser")
+    : t("tournament.match.winner");
   const roundRef = formatRoundRefCompact(
     feeding.round,
     feeding.match_number,
-    feeding.path !== bracket.path ? feeding.path : undefined,
+    isLoserDrop ? feeding.path : undefined,
   );
   return `${prefix} ${roundRef}`.trim();
 };

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -262,7 +262,7 @@ const isLbFeedingToWb = (bracket: Bracket) => {
 <template>
   <template v-for="bracket in props.brackets" :key="bracket.id">
     <div
-      v-if="!(bracket.bye && !bracket.team_1 && !bracket.team_2)"
+      v-if="!bracket.bye || bracket.team_1 || bracket.team_2 || bracket.feeding_brackets?.length"
       :id="`bracket-${bracket.id}`"
       class="tournament-match cursor-pointer border-2 rounded-lg p-1 transition-all duration-200 hover:shadow-lg hover:shadow-blue-500/20 bg-gray-800/50 backdrop-blur-sm relative flex flex-col gap-2"
       :class="{

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -261,7 +261,7 @@ const isLbFeedingToWb = (bracket: Bracket) => {
             $t("tournament.match.round_match", {
               round: props.round,
               match: bracket.match_number,
-              prefix: bracket.path === "LB" ? "Losers" : "",
+              prefix: bracket.path === "LB" ? "LB" : (bracket.path === "WB" && stage.type === e_tournament_stage_types_enum.DoubleElimination ? "WB" : ""),
             })
           }}
           <span
@@ -337,36 +337,38 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                   >
                     #{{ bracket.team_1_seed }}
                   </span>
-                  <span
-                    v-else-if="
-                      bracket.path !== 'WB' &&
-                      (getFeedingBracketAt(bracket, 'WB', 0)?.team_1_seed ||
-                        getFeedingBracketAt(bracket, 'WB', 0)?.team_2_seed)
-                    "
-                    class="text-xs text-gray-200/70 bg-gray-700/60 border border-gray-800 rounded px-1.5 py-0.5"
-                  >
-                    #{{
-                      getFeedingBracketAt(bracket, "WB", 0)?.team_1_seed || "?"
-                    }}<span
-                      v-if="getFeedingBracketAt(bracket, 'WB', 0)?.team_2_seed"
-                      >/{{
-                        getFeedingBracketAt(bracket, "WB", 0)?.team_2_seed
-                      }}</span
+                  <template v-if="!bracket.team_1">
+                    <span
+                      v-if="
+                        bracket.path !== 'WB' &&
+                        (getFeedingBracketAt(bracket, 'WB', 0)?.team_1_seed ||
+                          getFeedingBracketAt(bracket, 'WB', 0)?.team_2_seed)
+                      "
+                      class="text-xs text-gray-200/70 bg-gray-700/60 border border-gray-800 rounded px-1.5 py-0.5"
                     >
-                  </span>
-                  <!-- LB: show only WB feeds in Team 1/2 -->
-                  <template
-                    v-if="
-                      bracket.path === 'LB' &&
-                      getFeedingBracketAt(bracket, 'WB', 0)
-                    "
-                  >
-                    {{
-                      formatFeedingText(
-                        bracket,
-                        getFeedingBracketAt(bracket, "WB", 0),
-                      )
-                    }}
+                      #{{
+                        getFeedingBracketAt(bracket, "WB", 0)?.team_1_seed || "?"
+                      }}<span
+                        v-if="getFeedingBracketAt(bracket, 'WB', 0)?.team_2_seed"
+                        >/{{
+                          getFeedingBracketAt(bracket, "WB", 0)?.team_2_seed
+                        }}</span
+                      >
+                    </span>
+                    <!-- LB: show only WB feeds in Team 1/2 -->
+                    <template
+                      v-if="
+                        bracket.path === 'LB' &&
+                        getFeedingBracketAt(bracket, 'WB', 0)
+                      "
+                    >
+                      {{
+                        formatFeedingText(
+                          bracket,
+                          getFeedingBracketAt(bracket, "WB", 0),
+                        )
+                      }}
+                    </template>
                   </template>
                   {{ getTeamName(bracket.team_1) }}
                 </span>
@@ -398,36 +400,38 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                   >
                     #{{ bracket.team_2_seed }}
                   </span>
-                  <span
-                    v-else-if="
-                      bracket.path === 'LB' &&
-                      (getFeedingBracketAt(bracket, 'WB', 1)?.team_1_seed ||
-                        getFeedingBracketAt(bracket, 'WB', 1)?.team_2_seed)
-                    "
-                    class="text-xs text-gray-200/70 bg-gray-700/60 border border-gray-800 rounded px-1.5 py-0.5"
-                  >
-                    #{{
-                      getFeedingBracketAt(bracket, "WB", 1)?.team_1_seed || "?"
-                    }}<span
-                      v-if="getFeedingBracketAt(bracket, 'WB', 1)?.team_2_seed"
-                      >/{{
-                        getFeedingBracketAt(bracket, "WB", 1)?.team_2_seed
-                      }}</span
+                  <template v-if="!bracket.team_2">
+                    <span
+                      v-if="
+                        bracket.path === 'LB' &&
+                        (getFeedingBracketAt(bracket, 'WB', 1)?.team_1_seed ||
+                          getFeedingBracketAt(bracket, 'WB', 1)?.team_2_seed)
+                      "
+                      class="text-xs text-gray-200/70 bg-gray-700/60 border border-gray-800 rounded px-1.5 py-0.5"
                     >
-                  </span>
-                  <!-- LB: show only WB feeds in Team 1/2 -->
-                  <template
-                    v-else-if="
-                      bracket.path === 'LB' &&
-                      getFeedingBracketAt(bracket, 'WB', 1)
-                    "
-                  >
-                    {{
-                      formatFeedingText(
-                        bracket,
-                        getFeedingBracketAt(bracket, "WB", 1),
-                      )
-                    }}
+                      #{{
+                        getFeedingBracketAt(bracket, "WB", 1)?.team_1_seed || "?"
+                      }}<span
+                        v-if="getFeedingBracketAt(bracket, 'WB', 1)?.team_2_seed"
+                        >/{{
+                          getFeedingBracketAt(bracket, "WB", 1)?.team_2_seed
+                        }}</span
+                      >
+                    </span>
+                    <!-- LB: show only WB feeds in Team 1/2 -->
+                    <template
+                      v-if="
+                        bracket.path === 'LB' &&
+                        getFeedingBracketAt(bracket, 'WB', 1)
+                      "
+                    >
+                      {{
+                        formatFeedingText(
+                          bracket,
+                          getFeedingBracketAt(bracket, "WB", 1),
+                        )
+                      }}
+                    </template>
                   </template>
                 </span>
                 {{ getTeamName(bracket.team_2) }}

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -178,6 +178,30 @@ const getFeedingBracketAt = (
   return getFeedingBracketsByPath(bracket, path)[index];
 };
 
+/**
+ * Get the WB feeding bracket for a given team slot (1 or 2).
+ * In LB R1, there are two WB feeds mapped 1:1 to slots.
+ * In later LB rounds (R2, R4, etc.), there's only one WB feed.
+ * That single feed should appear in whichever slot doesn't already
+ * have a resolved team (the other slot is filled by an LB feed).
+ */
+const getWbFeedForSlot = (
+  bracket: Bracket,
+  slot: 1 | 2,
+): FeedingBracket | undefined => {
+  const wbFeeds = getFeedingBracketsByPath(bracket, "WB");
+  if (wbFeeds.length === 0) return undefined;
+
+  // Two or more WB feeds (e.g. LB R1): direct index mapping
+  if (wbFeeds.length >= 2) return wbFeeds[slot - 1];
+
+  // Single WB feed: show in slot 1 if team_1 is empty, slot 2 if team_1 is filled
+  if (slot === 1 && !bracket.team_1) return wbFeeds[0];
+  if (slot === 2 && bracket.team_1) return wbFeeds[0];
+
+  return undefined;
+};
+
 const isShowingDestinations = (bracket: Bracket) => {
   return bracket.path === "WB" && !bracket.match;
 };
@@ -358,17 +382,17 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                     <span
                       v-if="
                         bracket.path !== 'WB' &&
-                        (getFeedingBracketAt(bracket, 'WB', 0)?.team_1_seed ||
-                          getFeedingBracketAt(bracket, 'WB', 0)?.team_2_seed)
+                        (getWbFeedForSlot(bracket, 1)?.team_1_seed ||
+                          getWbFeedForSlot(bracket, 1)?.team_2_seed)
                       "
                       class="text-xs text-gray-200/70 bg-gray-700/60 border border-gray-800 rounded px-1.5 py-0.5"
                     >
                       #{{
-                        getFeedingBracketAt(bracket, "WB", 0)?.team_1_seed || "?"
+                        getWbFeedForSlot(bracket, 1)?.team_1_seed || "?"
                       }}<span
-                        v-if="getFeedingBracketAt(bracket, 'WB', 0)?.team_2_seed"
+                        v-if="getWbFeedForSlot(bracket, 1)?.team_2_seed"
                         >/{{
-                          getFeedingBracketAt(bracket, "WB", 0)?.team_2_seed
+                          getWbFeedForSlot(bracket, 1)?.team_2_seed
                         }}</span
                       >
                     </span>
@@ -376,13 +400,13 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                     <template
                       v-if="
                         bracket.path === 'LB' &&
-                        getFeedingBracketAt(bracket, 'WB', 0)
+                        getWbFeedForSlot(bracket, 1)
                       "
                     >
                       {{
                         formatFeedingText(
                           bracket,
-                          getFeedingBracketAt(bracket, "WB", 0),
+                          getWbFeedForSlot(bracket, 1),
                         )
                       }}
                     </template>
@@ -421,17 +445,17 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                     <span
                       v-if="
                         bracket.path === 'LB' &&
-                        (getFeedingBracketAt(bracket, 'WB', 1)?.team_1_seed ||
-                          getFeedingBracketAt(bracket, 'WB', 1)?.team_2_seed)
+                        (getWbFeedForSlot(bracket, 2)?.team_1_seed ||
+                          getWbFeedForSlot(bracket, 2)?.team_2_seed)
                       "
                       class="text-xs text-gray-200/70 bg-gray-700/60 border border-gray-800 rounded px-1.5 py-0.5"
                     >
                       #{{
-                        getFeedingBracketAt(bracket, "WB", 1)?.team_1_seed || "?"
+                        getWbFeedForSlot(bracket, 2)?.team_1_seed || "?"
                       }}<span
-                        v-if="getFeedingBracketAt(bracket, 'WB', 1)?.team_2_seed"
+                        v-if="getWbFeedForSlot(bracket, 2)?.team_2_seed"
                         >/{{
-                          getFeedingBracketAt(bracket, "WB", 1)?.team_2_seed
+                          getWbFeedForSlot(bracket, 2)?.team_2_seed
                         }}</span
                       >
                     </span>
@@ -439,13 +463,13 @@ const isLbFeedingToWb = (bracket: Bracket) => {
                     <template
                       v-if="
                         bracket.path === 'LB' &&
-                        getFeedingBracketAt(bracket, 'WB', 1)
+                        getWbFeedForSlot(bracket, 2)
                       "
                     >
                       {{
                         formatFeedingText(
                           bracket,
-                          getFeedingBracketAt(bracket, "WB", 1),
+                          getWbFeedForSlot(bracket, 2),
                         )
                       }}
                     </template>

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -313,16 +313,30 @@ const isLbFeedingToWb = (bracket: Bracket) => {
       <!-- Team Display -->
       <div class="flex flex-col gap-2">
         <template v-if="bracket.bye">
-          <!-- Bye round: show only the team that exists -->
-          <div v-if="bracket.team_1 || bracket.team_2" class="items-center">
-            <div class="bg-gray-600 text-gray-300 rounded py-1 px-4">
+          <!-- Bye round: show both slots for consistent height -->
+          <div class="items-center">
+            <div class="bg-gray-600 text-gray-300 rounded py-1 px-4 min-h-8">
               <span class="flex items-center gap-2">
                 <span
-                  v-if="bracket.team_1_seed || bracket.team_2_seed"
+                  v-if="bracket.team_1_seed"
                   class="text-xs text-gray-200/80 bg-gray-700/70 border border-gray-800 rounded px-1.5 py-0.5"
                 >
-                  #{{ bracket.team_1_seed || bracket.team_2_seed }}
+                  #{{ bracket.team_1_seed }}
                 </span>
+                {{ getTeamName(bracket.team_1) }}
+              </span>
+            </div>
+          </div>
+          <div class="items-center">
+            <div class="bg-gray-600 text-gray-300 rounded py-1 px-4 min-h-8">
+              <span class="flex items-center gap-2">
+                <span
+                  v-if="bracket.team_2_seed"
+                  class="text-xs text-gray-200/80 bg-gray-700/70 border border-gray-800 rounded px-1.5 py-0.5"
+                >
+                  #{{ bracket.team_2_seed }}
+                </span>
+                {{ getTeamName(bracket.team_2) }}
               </span>
             </div>
           </div>
@@ -461,7 +475,7 @@ const isLbFeedingToWb = (bracket: Bracket) => {
             }}
           </div>
         </div>
-        <div v-if="bracket.loser_bracket" class="text-center">
+        <div v-if="bracket.loser_bracket && !bracket.bye" class="text-center">
           <div class="text-xs text-red-400 font-medium">
             {{
               formatDestinationText(

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -206,15 +206,32 @@ const formatRoundRef = (
     : t(`tournament.match.${pathPrefix}round_ref`, { round });
 };
 
+const formatRoundRefCompact = (
+  round: number,
+  match_number?: number,
+  path?: string,
+) => {
+  const pathPrefix = path === "WB" ? "wb_" : path === "LB" ? "lb_" : "";
+  return match_number
+    ? t(`tournament.match.${pathPrefix}round_match_compact`, {
+        round,
+        match: match_number,
+      })
+    : t(`tournament.match.${pathPrefix}round_compact`, { round });
+};
+
 const formatFeedingText = (bracket: Bracket, feeding?: FeedingBracket) => {
   if (!feeding) return "";
-  const prefix = getFeedPrefix(bracket.path, feeding.path);
-  const roundMatch = formatRoundRef(
+  const prefix =
+    bracket.path === feeding.path
+      ? t("tournament.match.winner")
+      : t("tournament.match.loser");
+  const roundRef = formatRoundRefCompact(
     feeding.round,
     feeding.match_number,
     feeding.path !== bracket.path ? feeding.path : undefined,
   );
-  return `${prefix} ${roundMatch}`.trim();
+  return `${prefix} ${roundRef}`.trim();
 };
 
 const formatDestinationText = (

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -179,7 +179,8 @@ const getSortedFeeds = (bracket: Bracket): FeedingBracket[] => {
     const aLoser = a.loser_parent_bracket_id === bracket.id ? 0 : 1;
     const bLoser = b.loser_parent_bracket_id === bracket.id ? 0 : 1;
     if (aLoser !== bLoser) return aLoser - bLoser;
-    if ((a.round ?? 0) !== (b.round ?? 0)) return (a.round ?? 0) - (b.round ?? 0);
+    if ((a.round ?? 0) !== (b.round ?? 0))
+      return (a.round ?? 0) - (b.round ?? 0);
     return (a.match_number ?? 0) - (b.match_number ?? 0);
   });
 };
@@ -199,7 +200,10 @@ const formatRoundRef = (
 ) => {
   const pathPrefix = path === "WB" ? "wb_" : path === "LB" ? "lb_" : "";
   return match_number
-    ? t(`tournament.match.${pathPrefix}round_match_ref`, { round, match: match_number })
+    ? t(`tournament.match.${pathPrefix}round_match_ref`, {
+        round,
+        match: match_number,
+      })
     : t(`tournament.match.${pathPrefix}round_ref`, { round });
 };
 
@@ -283,7 +287,11 @@ const getFeedForDisplayRow = (
   const hintFeeds = sorted.filter(needsHint);
   const noHintFeeds = sorted.filter((f) => !needsHint(f));
 
-  if (sorted.length === 2 && hintFeeds.length === 1 && noHintFeeds.length === 1) {
+  if (
+    sorted.length === 2 &&
+    hintFeeds.length === 1 &&
+    noHintFeeds.length === 1
+  ) {
     return row === 1 ? noHintFeeds[0] : hintFeeds[0];
   }
 
@@ -318,7 +326,12 @@ const shouldShowCrossBracketDestination = (
 <template>
   <template v-for="bracket in props.brackets" :key="bracket.id">
     <div
-      v-if="!bracket.bye || bracket.team_1 || bracket.team_2 || bracket.feeding_brackets?.length"
+      v-if="
+        !bracket.bye ||
+        bracket.team_1 ||
+        bracket.team_2 ||
+        bracket.feeding_brackets?.length
+      "
       :id="`bracket-${bracket.id}`"
       class="tournament-match cursor-pointer border-2 rounded-lg p-1 transition-all duration-200 hover:shadow-lg hover:shadow-blue-500/20 bg-gray-800/50 backdrop-blur-sm relative flex flex-col gap-2"
       :class="{
@@ -340,7 +353,14 @@ const shouldShowCrossBracketDestination = (
             $t("tournament.match.round_match", {
               round: props.round,
               match: bracket.match_number,
-              prefix: bracket.path === "LB" ? "LB" : (bracket.path === "WB" && stage.type === e_tournament_stage_types_enum.DoubleElimination ? "WB" : ""),
+              prefix:
+                bracket.path === "LB"
+                  ? "LB"
+                  : bracket.path === "WB" &&
+                      stage.type ===
+                        e_tournament_stage_types_enum.DoubleElimination
+                    ? "WB"
+                    : "",
             })
           }}
           <span

--- a/components/tournament/TournamentMatch.vue
+++ b/components/tournament/TournamentMatch.vue
@@ -168,9 +168,9 @@ const handleClick = (event: MouseEvent, bracket: Bracket) => {
 
 /**
  * Get the feeding bracket for a given team slot (1 or 2).
- * Uses DB relationships: feeds whose parent_bracket_id points here
- * are winner feeds, feeds whose loser_parent_bracket_id points here
- * are loser drops. Slot 1 gets the first feed, slot 2 gets the second.
+ * Sorts feeds to match the DB slot assignment order from
+ * assign_team_to_bracket_slot: loser drops first, then winner
+ * feeds, then by round and match_number within each group.
  */
 const getFeedForSlot = (
   bracket: Bracket,
@@ -178,7 +178,14 @@ const getFeedForSlot = (
 ): FeedingBracket | undefined => {
   const feeds = bracket.feeding_brackets || [];
   if (feeds.length === 0) return undefined;
-  return feeds[slot - 1];
+  const sorted = [...feeds].sort((a, b) => {
+    const aLoser = a.loser_parent_bracket_id === bracket.id ? 0 : 1;
+    const bLoser = b.loser_parent_bracket_id === bracket.id ? 0 : 1;
+    if (aLoser !== bLoser) return aLoser - bLoser;
+    if ((a.round ?? 0) !== (b.round ?? 0)) return (a.round ?? 0) - (b.round ?? 0);
+    return (a.match_number ?? 0) - (b.match_number ?? 0);
+  });
+  return sorted[slot - 1];
 };
 
 /**
@@ -228,7 +235,7 @@ const formatFeedingText = (bracket: Bracket, feeding?: FeedingBracket) => {
   const roundRef = formatRoundRefCompact(
     feeding.round,
     feeding.match_number,
-    isLoserDrop ? feeding.path : undefined,
+    feeding.path,
   );
   return `${prefix} ${roundRef}`.trim();
 };

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1253,6 +1253,10 @@
             "winner_bracket_arrow": "Winner Bracket \u2192",
             "round_match_ref": "Round {round}, Match {match}",
             "round_ref": "Round {round}",
+            "wb_round_match_ref": "WB Round {round}, Match {match}",
+            "wb_round_ref": "WB Round {round}",
+            "lb_round_match_ref": "LB Round {round}, Match {match}",
+            "lb_round_ref": "LB Round {round}",
             "third_place_decider": "3rd Place Decider"
         },
         "round_labels": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1257,6 +1257,14 @@
             "wb_round_ref": "WB Round {round}",
             "lb_round_match_ref": "LB Round {round}, Match {match}",
             "lb_round_ref": "LB Round {round}",
+            "winner": "Winner",
+            "loser": "Loser",
+            "round_match_compact": "R{round}M{match}",
+            "round_compact": "R{round}",
+            "wb_round_match_compact": "WB R{round}M{match}",
+            "wb_round_compact": "WB R{round}",
+            "lb_round_match_compact": "LB R{round}M{match}",
+            "lb_round_compact": "LB R{round}",
             "third_place_decider": "3rd Place Decider"
         },
         "round_labels": {

--- a/pages/settings/application/servers.vue
+++ b/pages/settings/application/servers.vue
@@ -95,15 +95,10 @@ definePageMeta({
             </FormItem>
           </FormField>
 
-          <FormField
-            v-slot="{ componentField }"
-            name="disk_warning_percent"
-          >
+          <FormField v-slot="{ componentField }" name="disk_warning_percent">
             <FormItem>
               <FormLabel>{{
-                $t(
-                  "pages.settings.application.servers.disk_warning_percent",
-                )
+                $t("pages.settings.application.servers.disk_warning_percent")
               }}</FormLabel>
               <FormDescription>{{
                 $t(
@@ -115,15 +110,10 @@ definePageMeta({
             </FormItem>
           </FormField>
 
-          <FormField
-            v-slot="{ componentField }"
-            name="disk_critical_percent"
-          >
+          <FormField v-slot="{ componentField }" name="disk_critical_percent">
             <FormItem>
               <FormLabel>{{
-                $t(
-                  "pages.settings.application.servers.disk_critical_percent",
-                )
+                $t("pages.settings.application.servers.disk_critical_percent")
               }}</FormLabel>
               <FormDescription>{{
                 $t(
@@ -205,11 +195,13 @@ export default {
                 },
                 {
                   name: "reserved_disk_space_fresh_gb",
-                  value: this.form.values.reserved_disk_space_fresh_gb?.toString(),
+                  value:
+                    this.form.values.reserved_disk_space_fresh_gb?.toString(),
                 },
                 {
                   name: "reserved_disk_space_existing_gb",
-                  value: this.form.values.reserved_disk_space_existing_gb?.toString(),
+                  value:
+                    this.form.values.reserved_disk_space_existing_gb?.toString(),
                 },
                 {
                   name: "disk_warning_percent",

--- a/pages/tournaments/[tournamentId]/index.vue
+++ b/pages/tournaments/[tournamentId]/index.vue
@@ -808,6 +808,10 @@ export default {
                         group: true,
                         match_number: true,
                         path: true,
+                        parent_bracket_id: true,
+                        loser_parent_bracket_id: true,
+                        team_1_seed: true,
+                        team_2_seed: true,
                       },
                       match: {
                         id: true,

--- a/types/tournament.ts
+++ b/types/tournament.ts
@@ -13,6 +13,8 @@ export interface Bracket {
     round: number;
     match_number?: number;
     path?: string;
+    parent_bracket_id?: string;
+    loser_parent_bracket_id?: string;
     team_1_seed?: number;
     team_2_seed?: number;
   }>;

--- a/types/tournament.ts
+++ b/types/tournament.ts
@@ -13,6 +13,7 @@ export interface Bracket {
     round: number;
     match_number?: number;
     path?: string;
+    group?: number;
     parent_bracket_id?: string;
     loser_parent_bracket_id?: string;
     team_1_seed?: number;


### PR DESCRIPTION
## Summary
- Loser destination labels on WB matches now show "Loser → **LB** Round X, Match Y" instead of "Loser → Round X, Match Y"
- Feeder labels in LB matches now show "Loser of **WB** Round X, Match Y" instead of "Loser of Round X, Match Y"
- Winner destination label on LB Final now shows "Winner → **WB** Round X, Match Y"
- Moved red loser destination labels from inline (inside team rows) to below the match card, consistent with the green winner destination label position

## Test plan
- [ ] Verify WB matches show "Loser → LB Round X, Match Y" in red below the card
- [ ] Verify LB feeder slots show "Loser of WB Round X, Match Y" for WB drops
- [ ] Verify LB Final shows "Winner → WB Round X, Match Y" in green below the card
- [ ] Verify single elimination brackets are unaffected (no path prefix)
- [ ] Verify red labels appear below the card (not inline in team rows)