### PR TITLE
bug: fix match mode redundancy and stage defaults

### DIFF
--- a/components/MatchOptions.vue
+++ b/components/MatchOptions.vue
@@ -892,7 +892,7 @@ import { Card } from "~/components/ui/card";
                 </FormField>
 
                 <FormField
-                  v-if="canSetMatchCancellation"
+                  v-if="canSetMatchCancellation && !hideMatchMode"
                   v-slot="{ componentField }"
                   name="match_mode"
                 >
@@ -1091,6 +1091,11 @@ export default {
       default: false,
     },
     hideBestOf: {
+      required: false,
+      type: Boolean,
+      default: false,
+    },
+    hideMatchMode: {
       required: false,
       type: Boolean,
       default: false,

--- a/components/tournament/TournamentForm.vue
+++ b/components/tournament/TournamentForm.vue
@@ -14,7 +14,7 @@ import MatchOptions from "~/components/MatchOptions.vue";
 
 <template>
   <form @submit.prevent="updateCreateTournament" class="grid gap-4">
-    <MatchOptions :form="form" :force-veto="true" :hide-best-of="true">
+    <MatchOptions :form="form" :force-veto="true" :hide-best-of="true" :hide-match-mode="true">
       <FormField v-slot="{ componentField }" name="name">
         <FormItem>
           <FormLabel>{{ $t("tournament.form.name") }}</FormLabel>

--- a/components/tournament/TournamentStageForm.vue
+++ b/components/tournament/TournamentStageForm.vue
@@ -844,6 +844,7 @@ export default {
         } else {
           this.form.setValues({
             groups: 1,
+            default_best_of: "1",
           });
           this.setDefaultAdvancedSettings();
         }

--- a/components/tournament/TournamentStageForm.vue
+++ b/components/tournament/TournamentStageForm.vue
@@ -612,6 +612,40 @@ import { $ } from "~/generated/zeus";
                   <FormMessage />
                 </FormItem>
               </FormField>
+
+              <FormField
+                v-if="canSetMatchMode"
+                v-slot="{ componentField }"
+                name="match_mode"
+              >
+                <FormItem>
+                  <FormLabel class="text-lg font-semibold">{{
+                    $t("match.options.advanced.match_mode.label")
+                  }}</FormLabel>
+                  <FormDescription>{{
+                    $t("match.options.advanced.match_mode.description")
+                  }}</FormDescription>
+                  <Select v-bind="componentField">
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectItem
+                          :value="mode.value"
+                          v-for="mode in matchModeSettings"
+                          :key="mode.value"
+                        >
+                          {{ mode.display }}
+                        </SelectItem>
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              </FormField>
             </div>
           </Card>
         </div>
@@ -635,6 +669,7 @@ import {
   e_timeout_settings_enum,
   e_check_in_settings_enum,
   e_player_roles_enum,
+  e_match_mode_enum,
 } from "~/generated/zeus";
 import { toTypedSchema } from "@vee-validate/zod";
 import { useApplicationSettingsStore } from "~/stores/ApplicationSettings";
@@ -729,6 +764,9 @@ export default {
               tech_timeout_setting: z
                 .string()
                 .default(e_timeout_settings_enum.Admin),
+              match_mode: z
+                .string()
+                .default(e_match_mode_enum.auto),
             })
             .refine(
               (data) => parseInt(data.min_teams) <= parseInt(data.max_teams),
@@ -797,6 +835,10 @@ export default {
                 stage.options?.tech_timeout_setting ??
                 this.tournament?.options?.tech_timeout_setting ??
                 e_timeout_settings_enum.Admin,
+              match_mode:
+                stage.options?.match_mode ??
+                this.tournament?.options?.match_mode ??
+                e_match_mode_enum.auto,
             });
           }
         } else {
@@ -978,6 +1020,23 @@ export default {
         },
       ];
     },
+    canSetMatchMode() {
+      return useAuthStore().isRoleAbove(
+        e_player_roles_enum.tournament_organizer,
+      );
+    },
+    matchModeSettings(): EnumSetting[] {
+      return [
+        {
+          display: this.$t("match.options.advanced.match_mode.options.auto"),
+          value: e_match_mode_enum.auto,
+        },
+        {
+          display: this.$t("match.options.advanced.match_mode.options.admin"),
+          value: e_match_mode_enum.admin,
+        },
+      ];
+    },
   },
   methods: {
     setDefaultAdvancedSettings() {
@@ -992,6 +1051,8 @@ export default {
         ready_setting: options.ready_setting ?? e_ready_settings_enum.Players,
         tech_timeout_setting:
           options.tech_timeout_setting ?? e_timeout_settings_enum.Admin,
+        match_mode:
+          options.match_mode ?? e_match_mode_enum.auto,
       });
     },
     setDefaultRegion() {
@@ -1016,7 +1077,8 @@ export default {
         form.region_veto !== tournamentOptions.region_veto ||
         form.check_in_setting !== tournamentOptions.check_in_setting ||
         form.ready_setting !== tournamentOptions.ready_setting ||
-        form.tech_timeout_setting !== tournamentOptions.tech_timeout_setting
+        form.tech_timeout_setting !== tournamentOptions.tech_timeout_setting ||
+        form.match_mode !== (tournamentOptions.match_mode ?? e_match_mode_enum.auto)
       ) {
         return true;
       }
@@ -1049,6 +1111,7 @@ export default {
           check_in_setting: form.check_in_setting,
           ready_setting: form.ready_setting,
           tech_timeout_setting: form.tech_timeout_setting,
+          match_mode: form.match_mode,
           // Keep tournament defaults for all other fields
           mr: tournamentOptions.mr,
           type: tournamentOptions.type,
@@ -1080,6 +1143,7 @@ export default {
                   "tech_timeout_setting",
                   "e_timeout_settings_enum!",
                 ),
+                match_mode: $("match_mode", "e_match_mode_enum!"),
                 mr: $("mr", "Int!"),
                 type: $("type", "e_match_types_enum!"),
                 best_of: $("best_of", "Int!"),
@@ -1115,6 +1179,7 @@ export default {
           check_in_setting: form.check_in_setting,
           ready_setting: form.ready_setting,
           tech_timeout_setting: form.tech_timeout_setting,
+          match_mode: form.match_mode,
           // Keep tournament defaults for all other fields
           mr: tournamentOptions.mr,
           type: tournamentOptions.type,
@@ -1143,6 +1208,7 @@ export default {
                   "tech_timeout_setting",
                   "e_timeout_settings_enum!",
                 ),
+                match_mode: $("match_mode", "e_match_mode_enum!"),
                 mr: $("mr", "Int!"),
                 type: $("type", "e_match_types_enum!"),
                 best_of: $("best_of", "Int!"),


### PR DESCRIPTION
## Summary
- Remove redundant Match Mode (Auto/Admin) dropdown from tournament creation form — the Auto Start toggle already controls tournament-wide scheduling
- Add Match Mode override to stage advanced settings, where per-stage granularity is actually useful
- Preselect "Best of 1" as the default when creating a new stage instead of showing an empty dropdown

## Test plan
- [ ] Create a tournament — verify Match Mode no longer appears in advanced settings
- [ ] Create a stage — verify Match Mode appears in advanced stage settings (for tournament_organizer+ roles)
- [ ] Create a stage — verify Default Best Of is preselected to "Best of 1"
- [ ] Edit an existing stage — verify Match Mode loads from stage options (or falls back to tournament options)