### PR TITLE
fix: validate redirect parameter to prevent open redirect

### DIFF
--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -71,7 +71,10 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   if (hasMe && to.path === "/login") {
     if (to.query.redirect) {
-      return navigateTo(decodeURIComponent(to.query.redirect as string));
+      const redirectPath = decodeURIComponent(to.query.redirect as string);
+      if (redirectPath.startsWith("/") && !redirectPath.startsWith("//")) {
+        return navigateTo(redirectPath);
+      }
     }
     return navigateTo("/");
   }


### PR DESCRIPTION
## Summary
- Validates redirect query parameter in auth middleware to only allow relative paths
- Rejects absolute URLs and protocol-relative URLs (`//evil.com`) to prevent open redirect attacks
- Invalid redirects fall through to default `/` navigation

## Test plan
- [ ] Login with `?redirect=/play` — should redirect to `/play`
- [ ] Login with `?redirect=https://evil.com` — should redirect to `/`
- [ ] Login with `?redirect=//evil.com` — should redirect to `/`
- [ ] Login without redirect param — should redirect to `/`

Closes 5stackgg/5stack-panel#383