### PR TITLE
fix: add WebRTC timeouts and fix auth/Apollo error handling

### DIFF
--- a/plugins/apollo.client.ts
+++ b/plugins/apollo.client.ts
@@ -78,7 +78,7 @@ export default defineNuxtPlugin((nuxtApp) => {
             "Invalid response from authorization hook",
           ].includes(graphqlError.message)
         ) {
-          return;
+          continue;
         }
 
         toast({

--- a/stores/AuthStore.ts
+++ b/stores/AuthStore.ts
@@ -85,50 +85,49 @@ export const useAuthStore = defineStore("auth", () => {
       });
     }
 
-    return await new Promise(async (resolve) => {
-      try {
-        const response = await getGraphqlClient().query({
-          query: generateQuery({
-            me: {
-              role: true,
-              steam_id: true,
-              discord_id: true,
-            },
-          }),
-          fetchPolicy: "network-only", // Disable cache
+    try {
+      const response = await getGraphqlClient().query({
+        query: generateQuery({
+          me: {
+            role: true,
+            steam_id: true,
+            discord_id: true,
+          },
+        }),
+        fetchPolicy: "network-only", // Disable cache
+      });
+
+      if (!response.data.me) {
+        return false;
+      }
+
+      socket.connect();
+
+      hasDiscordLinked.value = !!response.data.me.discord_id;
+
+      const wsClient = useNuxtApp().$wsClient as import("graphql-ws").Client;
+      wsClient.terminate();
+      await new Promise<void>((resolveWs) => {
+        const timeout = setTimeout(() => {
+          dispose();
+          resolveWs();
+        }, 10000);
+        const dispose = wsClient.on("connected", () => {
+          clearTimeout(timeout);
+          dispose();
+          resolveWs();
         });
+      });
 
-        if (!response.data.me) {
-          resolve(false);
-          return;
-        }
-
-        socket.connect();
-
-        hasDiscordLinked.value = !!response.data.me.discord_id;
-
-        const wsClient = useNuxtApp().$wsClient as import("graphql-ws").Client;
-        wsClient.terminate();
-        await new Promise<void>((resolveWs) => {
-          const timeout = setTimeout(() => {
-            dispose();
-            resolveWs();
-          }, 10000);
-          const dispose = wsClient.on("connected", () => {
-            clearTimeout(timeout);
-            dispose();
-            resolveWs();
-          });
-        });
-
+      return await new Promise<boolean>((resolve) => {
         subscribeToMe(response.data.me.steam_id, () => {
           resolve(true);
         });
-      } catch (error) {
-        console.warn("auth failure", error);
-        resolve(false);
-      }
-    });
+      });
+    } catch (error) {
+      console.warn("auth failure", error);
+      return false;
+    }
   }
 
   const isUser = computed(() => me.value?.role === e_player_roles_enum.user);

--- a/web-sockets/Webrtc.ts
+++ b/web-sockets/Webrtc.ts
@@ -81,7 +81,13 @@ class WebRTCClient {
     this.dataChannels.set(peer.id, dataChannel);
 
     return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.cleanupPeer(peer.id);
+        reject(new Error("Data channel open timeout"));
+      }, 10000);
+
       dataChannel.onopen = () => {
+        clearTimeout(timeout);
         resolve(dataChannel);
       };
 
@@ -90,6 +96,7 @@ class WebRTCClient {
       };
 
       dataChannel.onerror = (error: any) => {
+        clearTimeout(timeout);
         console.error(`[WebRTC] Data channel error for peer ${peer.id}:`, {
           label: dataChannel.label,
           readyState: dataChannel.readyState,
@@ -98,12 +105,13 @@ class WebRTCClient {
         reject(error);
       };
       dataChannel.onclose = () => {
+        clearTimeout(timeout);
         this.cleanupPeer(peer.id);
       };
     });
   }
 
-  private async createPeer(region: string): Promise<ExtendedPeer> {
+  private createPeer(region: string): Promise<ExtendedPeer> {
     return new Promise((resolve, reject) => {
       const peer = new Peer({
         trickle: true,
@@ -122,8 +130,15 @@ class WebRTCClient {
       peer.id = uuidv4();
       this.peers.set(peer.id, peer);
 
+      const timeout = setTimeout(() => {
+        peer.destroy();
+        this.cleanupPeer(peer.id);
+        reject(new Error("Peer connection timeout"));
+      }, 10000);
+
       peer
         .on("connect", () => {
+          clearTimeout(timeout);
           resolve(peer);
         })
         .on("signal", (data: any) => {
@@ -135,13 +150,16 @@ class WebRTCClient {
           });
         })
         .on("error", (err: Error) => {
+          clearTimeout(timeout);
           console.error(
             `[WebRTC] Peer connection error for peer ${peer.id}:`,
             err,
           );
+          peer.destroy();
           reject(err);
         })
         .on("close", () => {
+          clearTimeout(timeout);
           this.cleanupPeer(peer.id);
         });
     });


### PR DESCRIPTION
## Summary
- Webrtc.ts: Add 10s timeouts to `connect()` and `createPeer()` promises to prevent indefinite hangs. Remove unnecessary `async` keyword from `createPeer`. Destroy peer on error before rejecting.
- AuthStore.ts: Replace `new Promise(async (resolve) => {...})` anti-pattern with proper async/await to prevent swallowed rejections
- apollo.client.ts: Change `return` to `continue` in auth error handling so other GraphQL errors in the same response are still processed

Closes 5stackgg/5stack-panel#388, 5stackgg/5stack-panel#389, 5stackgg/5stack-panel#390

## Test plan
- [ ] Verify latency checks timeout after 10s instead of hanging indefinitely
- [ ] Verify WebRTC peer creation times out and cleans up on failure
- [ ] Verify auth flow works correctly after login/logout cycles
- [ ] Verify non-auth GraphQL errors still show toast notifications