### PR TITLE
chore: pt-BR translations

### DIFF
--- a/i18n/locales/pt_BR.json
+++ b/i18n/locales/pt_BR.json
@@ -8,56 +8,59 @@
     "view_tournament": "VER TORNEIO"
   },
   "toasts": {
-      "link_copied": "Link copiado",
-      "copy_failed": "Falha ao copiar",
-      "clip_deleted": "Clipe excluído",
-      "delete_failed": "Falha ao excluir",
-      "clip_removed_named": "\"{title}\" foi removido.",
-      "highlight_removed": "Highlight foi removido.",
-      "could_not_delete_clip": "Não foi possível excluir o clipe. Tente novamente.",
-      "demo_parsed": "Demo processada",
-      "demo_parse_failed": "Falha ao processar demo",
-      "reconnecting": "Reconectando",
-      "reconnecting_description": "Reemitindo a conexão com o servidor de jogo.",
-      "cant_switch": "Não é possível alternar",
-      "destination_not_ready": "a partida de destino não está pronta",
-      "stream_switched": "Stream alternado",
-      "stream_switched_description": "Pod reutilizado — o feed será redirecionado em alguns segundos.",
-      "switch_failed": "Falha ao alternar",
-      "gpu_session_stopped": "Sessão de GPU encerrada",
-      "stop_gpu_session": "encerrar sessão de GPU",
-      "request_failed": "requisição falhou",
-      "preview_reset_failed": "Não foi possível visualizar o reset da partida do torneio",
-      "resolve_validation_errors": "Por favor, resolva os erros de validação",
-      "set_winner_failed": "Não foi possível definir o vencedor selecionado",
-      "set_winner_failed_description": "O ID da lineup selecionada está ausente para esta partida.",
-      "match_reset_applied": "Reset da partida do torneio aplicado",
-      "match_reset_failed": "Não foi possível resetar a partida do torneio",
-      "please_try_again": "Por favor, tente novamente."
+    "link_copied": "Link copiado",
+    "copy_failed": "Falha ao copiar",
+    "clip_deleted": "Clipe excluído",
+    "delete_failed": "Falha ao excluir",
+    "clip_removed_named": "\"{title}\" foi removido.",
+    "highlight_removed": "Highlight foi removido.",
+    "could_not_delete_clip": "Não foi possível excluir o clipe. Tente novamente.",
+    "demo_parsed": "Demo processada",
+    "demo_parse_failed": "Falha ao processar demo",
+    "reconnecting": "Reconectando",
+    "reconnecting_description": "Reemitindo a conexão com o servidor de jogo.",
+    "cant_switch": "Não é possível alternar",
+    "destination_not_ready": "a partida de destino não está pronta",
+    "stream_switched": "Stream alternado",
+    "stream_switched_description": "Pod reutilizado — o feed será redirecionado em alguns segundos.",
+    "switch_failed": "Falha ao alternar",
+    "gpu_session_stopped": "Sessão de GPU encerrada",
+    "stop_gpu_session": "encerrar sessão de GPU",
+    "request_failed": "requisição falhou",
+    "preview_reset_failed": "Não foi possível visualizar o reset da partida do torneio",
+    "resolve_validation_errors": "Por favor, resolva os erros de validação",
+    "set_winner_failed": "Não foi possível definir o vencedor selecionado",
+    "set_winner_failed_description": "O ID da lineup selecionada está ausente para esta partida.",
+    "match_reset_applied": "Reset da partida do torneio aplicado",
+    "match_reset_failed": "Não foi possível resetar a partida do torneio",
+    "please_try_again": "Por favor, tente novamente.",
+    "hevc_missing_title": "Não é possível reproduzir este clipe",
+    "hevc_missing_body": "Este vídeo está codificado com HEVC (H.265). Seu navegador não consegue decodificá-lo — instale as Extensões de Vídeo HEVC no Windows para habilitar a reprodução:",
+    "hevc_missing_link": "Obter as Extensões de Vídeo HEVC"
   },
   "shortcut_groups": {
-      "playback": "Reprodução",
-      "kills": "Abates",
-      "spectate": "Assistir",
-      "quick_actions": "Ações rápidas",
-      "view": "Visualizar",
-      "switch_player": "Alternar jogador (slot 1–{count})",
-      "prev_spec": "Alvo anterior de espectador",
-      "next_spec": "Próximo alvo de espectador",
-      "lock_free_roam": "Bloquear / livre-roam",
-      "toggle_fullscreen": "Alternar tela cheia",
-      "hold_show_scoreboard": "Segure para mostrar o placar",
-      "show_help": "Mostrar esta ajuda",
-      "play_pause": "Reproduzir / pausar",
-      "skip_back_15s": "Voltar 15s",
-      "skip_forward_15s": "Avançar 15s",
-      "prev_round": "Round anterior",
-      "next_round": "Próximo round",
-      "prev_kill": "Abate anterior",
-      "next_kill": "Próximo abate",
-      "toggle_xray": "Alternar raio-x",
-      "hide_show_openhud": "Ocultar / mostrar OpenHud",
-      "reload_demo": "Recarregar demo"
+    "playback": "Reprodução",
+    "kills": "Abates",
+    "spectate": "Assistir",
+    "quick_actions": "Ações rápidas",
+    "view": "Visualizar",
+    "switch_player": "Alternar jogador (slot 1–{count})",
+    "prev_spec": "Alvo anterior de espectador",
+    "next_spec": "Próximo alvo de espectador",
+    "lock_free_roam": "Bloquear / livre-roam",
+    "toggle_fullscreen": "Alternar tela cheia",
+    "hold_show_scoreboard": "Segure para mostrar o placar",
+    "show_help": "Mostrar esta ajuda",
+    "play_pause": "Reproduzir / pausar",
+    "skip_back_15s": "Voltar 15s",
+    "skip_forward_15s": "Avançar 15s",
+    "prev_round": "Round anterior",
+    "next_round": "Próximo round",
+    "prev_kill": "Abate anterior",
+    "next_kill": "Próximo abate",
+    "toggle_xray": "Alternar raio-x",
+    "hide_show_openhud": "Ocultar / mostrar OpenHud",
+    "reload_demo": "Recarregar demo"
   },
   "recent_highlights": {
     "default_title": "Highlights Recentes"
@@ -219,7 +222,7 @@
     "upload_failed": "Falha ao enviar avatar",
     "remove_success": "Avatar removido com sucesso",
     "remove_failed": "Falha ao remover avatar",
-    "too_large": "Avatar muito grande",
+    "too_large": "A imagem tem que ser de {size}MB ou menor",
     "invalid_type": "Apenas PNG, JPG ou WebP são aceitos.",
     "uploading": "Enviando...",
     "drop_to_upload": "Solte para enviar",
@@ -274,20 +277,20 @@
       "no_tournaments_title": "Em espera — Nenhum torneio",
       "no_tournaments_description": "Nada ao vivo, agendado ou recentemente finalizado.",
       "filter": {
-          "search_placeholder": "Pesquisar torneios por nome…",
-          "status_all": "Todos",
-          "status_live": "Ao vivo",
-          "status_registration": "Aberto",
-          "status_upcoming": "Próximos",
-          "status_finished": "Finalizados",
-          "date_all": "Todo o período",
-          "date_7d": "Últimos 7 dias",
-          "date_30d": "Últimos 30 dias",
-          "date_90d": "Últimos 90 dias",
-          "date_6m": "Últimos 6 meses",
-          "date_1y": "Último ano",
-          "no_results_title": "Nenhum torneio corresponde",
-          "no_results_description": "Tente limpar os filtros ou ampliar sua pesquisa."
+        "search_placeholder": "Pesquisar torneios por nome…",
+        "status_all": "Todos",
+        "status_live": "Ao vivo",
+        "status_registration": "Aberto",
+        "status_upcoming": "Próximos",
+        "status_finished": "Finalizados",
+        "date_all": "Todo o período",
+        "date_7d": "Últimos 7 dias",
+        "date_30d": "Últimos 30 dias",
+        "date_90d": "Últimos 90 dias",
+        "date_6m": "Últimos 6 meses",
+        "date_1y": "Último ano",
+        "no_results_title": "Nenhum torneio corresponde",
+        "no_results_description": "Tente limpar os filtros ou ampliar sua pesquisa."
       },
       "tabs": {
         "upcoming": "Próximos",
@@ -667,6 +670,10 @@
           "highlights_section": "Highlights",
           "clip_video_codec": "Codec dos Highlights",
           "clip_video_codec_description": "H.265 (HEVC) gera arquivos ~30% menores na mesma qualidade visual e é decodificado por hardware nos navegadores modernos Chrome, Edge, Safari e iOS. Volta automaticamente para H.264 se a GPU não tiver NVENC HEVC.",
+          "clip_fps": "FPS do highlight",
+          "clip_fps_description": "Taxa de quadros de saída para highlights renderizados e clipes editados manualmente. 60 FPS é mais suave, mas dobra o trabalho de codificação e o tamanho do arquivo; 30 FPS é a opção mais leve.",
+          "clip_resolution": "Resolução do highlight",
+          "clip_resolution_description": "Resolução de saída padrão para highlights renderizados e clipes editados manualmente. Os usuários ainda podem substituir por clipe no diálogo de renderização. 1080p equilibra qualidade e tamanho de arquivo; 720p produz arquivos ~50% menores. Ambos se beneficiam quando os nós de GPU renderizam em 1440p — o streamer faz supersampling reduzindo para a resolução de saída selecionada.",
           "codec_h265": "H.265 / HEVC (recomendado)",
           "codec_h264": "H.264",
           "clip_bake_branding": "Incorporar chip do jogador + outro nos highlights*",
@@ -700,7 +707,11 @@
         "average_latency": "Latência",
         "preferred": "Preferido",
         "max_acceptable_latency": "Máximo Aceitável Latência",
-        "max_latency_description": "Se nenhuma região é preferida, matchmaking só usará regiões com latência abaixo deste valor."
+        "max_latency_description": "Se nenhuma região é preferida, matchmaking só usará regiões com latência abaixo deste valor.",
+        "show_match_ready_modal": {
+          "title": "Popup de partida pronta",
+          "description": "Mostrar um popup quando uma partida estiver pronta para você fazer o check-in. Quando desativado, você ainda pode fazer o check-in pelo botão na barra superior."
+        }
       }
     },
     "watch": {
@@ -708,6 +719,7 @@
       "upcoming_matches": "Próximas",
       "live_feed": "Feed Ao Vivo",
       "section_live_tournaments": "TORNEIOS.AO VIVO",
+      "section_streaming_now": "TRANSMITINDO.AGORA",
       "section_live_matches": "PARTIDAS.AO VIVO",
       "section_upcoming_tournaments": "TORNEIOS.PRÓXIMOS",
       "section_upcoming_matches": "PARTIDAS.PRÓXIMAS",
@@ -732,38 +744,38 @@
       "match_count": "partida | partidas",
       "clip_count": "clipe | clipes",
       "since": {
-          "all": "Todo o período",
-          "24h": "Últimas 24 horas",
-          "7d": "Últimos 7 dias",
-          "30d": "Últimos 30 dias",
-          "90d": "Últimos 90 dias"
+        "all": "Todo o período",
+        "24h": "Últimas 24 horas",
+        "7d": "Últimos 7 dias",
+        "30d": "Últimos 30 dias",
+        "90d": "Últimos 90 dias"
       },
       "kills": {
-          "any": "Qualquer abate",
-          "2": "2+ abates",
-          "3": "3+ abates",
-          "4": "4+ abates",
-          "5": "5 abates"
+        "2": "2+ abates",
+        "3": "3+ abates",
+        "4": "4+ abates",
+        "5": "5 abates",
+        "any": "Qualquer abate"
       },
       "view_modes": {
-          "matches": "Clipes de partidas",
-          "singles": "Clipes individuais"
+        "matches": "Clipes de partidas",
+        "singles": "Clipes individuais"
       },
       "visibility_filter": {
-          "all": "Todos",
-          "public": "Público",
-          "unlisted": "Não listado",
-          "private": "Privado"
+        "all": "Todos",
+        "public": "Público",
+        "unlisted": "Não listado",
+        "private": "Privado"
       },
       "empty": {
-          "no_match_filters": "Nenhum clipe corresponde a esses filtros",
-          "no_clips_yet": "Nenhum clipe aqui ainda",
-          "try_widening": "Tente ampliar os filtros ou limpar um.",
-          "try_different_admin": "Tente um filtro diferente — ou aguarde novos clipes serem renderizados.",
-          "check_back_soon": "Clipes públicos aparecerão aqui conforme forem renderizados. Volte em breve.",
-          "clear_player": "Limpar jogador",
-          "clear_date": "Limpar data",
-          "clear_kills": "Limpar abates"
+        "no_match_filters": "Nenhum clipe corresponde a esses filtros",
+        "no_clips_yet": "Nenhum clipe aqui ainda",
+        "try_widening": "Tente ampliar os filtros ou limpar um.",
+        "try_different_admin": "Tente um filtro diferente — ou aguarde novos clipes serem renderizados.",
+        "check_back_soon": "Clipes públicos aparecerão aqui conforme forem renderizados. Volte em breve.",
+        "clear_player": "Limpar jogador",
+        "clear_date": "Limpar data",
+        "clear_kills": "Limpar abates"
       }
     },
     "regions": {
@@ -845,7 +857,7 @@
         "top_percent": "Top {percent}%",
         "rank_of_total": "{rank} de {total}",
         "player_profile": "Perfil do Jogador",
-        "teams": "Equiopes",
+        "teams": "Equipes",
         "range": "Alcance",
         "loading_short": "Carregando...",
         "match_count": "{count} partidas",
@@ -870,23 +882,23 @@
         "acquiring_telemetry": "Obtendo telemetria…",
         "matches_section": "PARTIDAS",
         "elo_history_dialog": {
-            "eyebrow": "Progressão de ELO — Detalhada",
-            "title": "{name} — Detalhe de ELO",
-            "default_player": "Jogador",
-            "description": "Cada partida plotada em resolução completa. A página principal agrupa neste intervalo para mostrar a tendência; aqui você vê cada Δ.",
-            "mode": "Modo",
-            "current": "Atual",
-            "peak": "Teto",
-            "lowest": "Mínimo",
-            "matches": "Partidas",
-            "win_rate": "Taxa de vitórias",
-            "avg_delta_elo": "ΔELO médio:",
-            "loading_history": "Carregando histórico…",
-            "no_matches_window": "Nenhuma partida na janela selecionada",
-            "expand_to_all_time": "Expandir para todo o período",
-            "best_gain": "Maior ganho único",
-            "worst_loss": "Maior perda única",
-            "view_match": "Ver partida"
+          "eyebrow": "Progressão de ELO — Detalhada",
+          "title": "{name} — Detalhe de ELO",
+          "default_player": "Jogador",
+          "description": "Cada partida plotada em resolução completa. A página principal agrupa neste intervalo para mostrar a tendência; aqui você vê cada Δ.",
+          "mode": "Modo",
+          "current": "Atual",
+          "peak": "Teto",
+          "lowest": "Mínimo",
+          "matches": "Partidas",
+          "win_rate": "Taxa de vitórias",
+          "avg_delta_elo": "ΔELO médio:",
+          "loading_history": "Carregando histórico…",
+          "no_matches_window": "Nenhuma partida na janela selecionada",
+          "expand_to_all_time": "Expandir para todo o período",
+          "best_gain": "Maior ganho único",
+          "worst_loss": "Maior perda única",
+          "view_match": "Ver partida"
         }
       }
     },
@@ -1634,7 +1646,7 @@
     "team_name": "Nome da Equipe",
     "coaches": "Técnicos",
     "map_veto": "Veto de Mapa",
-    "round": "Rodada",
+    "round": "Round {number}",
     "stats": {
       "wins": "Vitórias",
       "losses": "Derrotas",
@@ -2193,10 +2205,10 @@
     "keyboard_shortcuts": "Atalhos de teclado",
     "up_next": "A Seguir",
     "head_to_head_matrix": {
-        "viewing": "Visualizando",
-        "damage": "Dano",
-        "your_weapons": "Suas armas",
-        "their_weapons": "Armas deles"
+      "viewing": "Visualizando",
+      "damage": "Dano",
+      "your_weapons": "Suas armas",
+      "their_weapons": "Armas deles"
     },
     "highlights_button": "Highlights",
     "team_stats_heading": "Estatísticas de {name}",
@@ -2800,21 +2812,21 @@
       "map_label": "Mapa",
       "all_maps": "Todos",
       "map_not_played": "Este mapa não foi jogado"
-      },
-      "player_strip": {
-          "highlights": "Highlights",
-          "overflow_more": "+{count} mais",
-          "default_clip_title": "Highlight",
-          "kills": "Kills",
-          "deaths": "Mortes",
-          "assists": "Assistências",
-          "adr": "ADR",
-          "hs_pct": "%HS",
-          "kd": "K/D"
-      },
-      "side_filter": {
-          "all": "Todos"
-      }
+    },
+    "player_strip": {
+      "highlights": "Highlights",
+      "overflow_more": "+{count} mais",
+      "default_clip_title": "Highlight",
+      "kills": "Kills",
+      "deaths": "Mortes",
+      "assists": "Assistências",
+      "adr": "ADR",
+      "hs_pct": "%HS",
+      "kd": "K/D"
+    },
+    "side_filter": {
+      "all": "Todos"
+    }
   },
   "ui": {
     "tooltips": {
@@ -2930,7 +2942,7 @@
       "banned": "Banido",
       "muted": "Silenciado (voz)",
       "gagged": "Censurado (texto)",
-      "add_friend": "Adicionar como amigo"
+      "add_friend": "Adicionar aos amigos"
     },
     "change_name": {
       "button": "Alterar Nome",
@@ -2973,13 +2985,13 @@
   "matchmaking": {
     "match_types": {
       "competitive": {
-        "description": "O clássico modo competitivo de 5 contra 5"
+        "description": "Modo competitivo clássico 5v5. Jogue em equipe, gerencie economia, execute estratégias e suba no ranking."
       },
       "wingman": {
-        "description": "Junte-se a um amigo e dispute partidas 2 contra 2 em ritmo acelerado."
+        "description": "Modo 2v2 em ritmo acelerado em mapas reduzidos. Junte-se a um amigo e dispute partidas 2v2 em ritmo acelerado. Rápido, objetivo e cooperativo. Perfeito para jogar com um amigo."
       },
       "duel": {
-        "description": "Modo de jogo 1 contra 1, perfeito para praticar habilidades individuais"
+        "description": "Modo 1v1 focado em habilidades individuais. Perfeito para treinar mira, posicionamento, reflexos e chamar seu amigo newba pra um X1 pra mostrar que você é fodão."
       }
     },
     "cancel_matchmaking": "Sair da Fila",
@@ -2994,6 +3006,10 @@
     "confirmed": "Confirmado",
     "ready": "Pronto",
     "locked_in": "Trancado",
+    "check_in": "Check In",
+    "go_to_match": "Ir para a Partida",
+    "disable_match_ready_modal_hint": "Não quer este popup?",
+    "disable_match_ready_modal_action": "Desabilite nas configurações do matchmaking",
     "invites": "Convites",
     "lobby": {
       "access": "Acesso à Lobby",
@@ -3017,7 +3033,6 @@
       "title": "Outros"
     },
     "banned": "Você está banido do matchmaking",
-    "go_to_match": "Ir para a Partida",
     "confirm_selection": "Entrar na Fila",
     "in_queue": "na fila",
     "temp_banned": "Você está temporariamente banido do matchmaking.",
@@ -3063,6 +3078,57 @@
     "remove_node": "Remover Nó",
     "show_update_logs": "Mostrar Logs de Atualizações",
     "edit_label": "Editar rótulo",
+    "edit_cs2_options": "Configurações de Vídeo do CS2",
+    "cs2_options": {
+      "title": "Configurações de Vídeo",
+      "description": "Configurações de vídeo por nó aplicadas quando este nó hospeda uma transmissão ao vivo, reprodução de demo ou tarefa em lote de highlights.",
+      "save": "Salvar",
+      "toast_saved": "Configurações de vídeo atualizadas",
+      "section_video": "Configurações de vídeo",
+      "section_video_description": "Ajuste a qualidade de renderização usada enquanto o CS2 é capturado neste nó.",
+      "preset": {
+          "title": "Predefinição de qualidade",
+          "description": "O modo Automático permite que o CS2 gere a configuração de vídeo no primeiro lançamento de acordo com a GPU real do nó. As predefinições Baixa / Média / Alta aplicam substituições explícitas sobre isso.",
+          "auto": "Automático (padrão)",
+          "auto_active": "Modo automático — o CS2 gerará sua própria configuração de vídeo no primeiro lançamento. Os campos abaixo são ignorados até que você escolha outra predefinição.",
+          "low": "Baixa",
+          "medium": "Média",
+          "high": "Alta"
+      },
+      "video": {
+          "resolution": "Resolução de renderização",
+          "resolution_desc": "Resolução em que o CS2 renderiza neste nó. A captura sempre reduz para 1080p antes da codificação — escolher 1440p faz supersampling (renderiza em 1440p → codifica em 1080p), exigindo mais GPU para bordas mais nítidas e anti-aliasing mais limpo no stream/clipe final. Os espectadores veem 1080p de qualquer forma.",
+          "aa": {
+              "label": "Anti-aliasing",
+              "description": "MSAA renderiza múltiplas amostras por pixel para bordas geométricas limpas; CMAA2 é um pós-processo mais barato que suaviza bordas, mas desfoca a imagem. São mutuamente exclusivos.",
+              "off": "Desativado",
+              "cmaa": "CMAA2 (barato)",
+              "msaa2": "MSAA 2x",
+              "msaa4": "MSAA 4x",
+              "msaa8": "MSAA 8x"
+          },
+          "r_texturefilteringquality": "Filtragem de textura",
+          "r_texturefilteringquality_desc": "Qualidade da filtragem anisotrópica. 0 = bilinear, 5 = aniso 16x.",
+          "shaderquality": "Qualidade dos shaders",
+          "shaderquality_desc": "0 = mais simples e rápido, 1 = destaques e reflexos complexos.",
+          "videocfg_shadow_quality": "Qualidade das sombras",
+          "videocfg_shadow_quality_desc": "Detalhe geral das sombras. Níveis mais altos melhoram a visibilidade tática à custa de FPS.",
+          "videocfg_dynamic_shadows": "Sombras dinâmicas",
+          "videocfg_dynamic_shadows_desc": "Sombras projetadas pelo sol e jogadores. Desativar economiza FPS.",
+          "videocfg_texture_detail": "Detalhe das texturas",
+          "videocfg_texture_detail_desc": "Resolução das texturas. Impacto mínimo no FPS com VRAM suficiente.",
+          "videocfg_particle_detail": "Detalhe das partículas",
+          "videocfg_particle_detail_desc": "Afeta fumaça, fogo e renderização de Molotov. Alto melhora a visibilidade da molotov, mas reduz FPS.",
+          "videocfg_ao_detail": "Oclusão de ambiente",
+          "videocfg_ao_detail_desc": "Sombras suaves de contato. Configurações competitivas geralmente mantêm desativado.",
+          "off": "Desativado",
+          "low": "Baixa",
+          "medium": "Média",
+          "high": "Alta",
+          "very_high": "Muito alta",
+          "auto": "Automático"
+      }
+    },
     "edit_ports": "Editar Portas",
     "edit_ports_description": "Configure o intervalo de portas para este nó",
     "port_start": "Porta Inicial",
@@ -3079,6 +3145,7 @@
       "csgo_installing": "CS:GO está sendo instalado neste nó",
       "ports_updated": "Portas Atualizadas",
       "label_updated": "Rótulo Atualizado",
+      "cs2_options_updated": "Configurações de vídeo atualizadas",
       "scheduling_updated": "Agendamento do Nó Atualizado"
     },
     "enable_scheduling": "Habilitar Agendamento",
@@ -3218,16 +3285,16 @@
     "next_clip": "Próximo clipe",
     "hide_xray": "Ocultar raio-x",
     "show_xray": "Mostrar raio-x"
-    },
-    "stream_deck_extras": {
-        "switching": "Trocando…",
-        "no_server": "Sem servidor",
-        "not_live_yet": "Ainda não está ao vivo",
-        "server_offline": "Servidor offline",
-        "switch_stream_here": "Trocar stream aqui"
-    },
-    "branding": {
-        "site_title_suffix": "Sistema de Gerenciamento de Counter-Strike"
+  },
+  "stream_deck_extras": {
+    "switching": "Trocando…",
+    "no_server": "Sem servidor",
+    "not_live_yet": "Ainda não está ao vivo",
+    "server_offline": "Servidor offline",
+    "switch_stream_here": "Trocar stream aqui"
+  },
+  "branding": {
+    "site_title_suffix": "Sistema de Gerenciamento de Counter-Strike"
   },
   "validation": {
     "map_pool_required": "O pool de mapas é necessário",
@@ -3374,37 +3441,37 @@
       "cancel": "Cancelar",
       "other_clips": "Outros clipes",
       "view_match": "Ver partida"
-      },
-      "render_queue": {
-          "in_flight": "Em andamento",
-          "cancel": "Cancelar",
-          "render": "Renderizar",
-          "upload": "Enviar",
-          "recently_finished": "Finalizado recentemente"
-      },
-      "visibility_section": "Visibilidade",
-      "create_dialog": {
-          "title": "Clipe automático",
-          "description": "Escolha um jogador e um pré-ajuste — o servidor analisa os abates da partida, monta os segmentos e renderiza um mp4.",
-          "player": "Jogador",
-          "pick_player_placeholder": "Escolha um jogador para destacar",
-          "no_players_yet": "Nenhum jogador encontrado ainda — aguarde a demo começar a rodar e tente novamente.",
-          "other_group": "Outros",
-          "preset": "Pré-ajuste",
-          "title_label": "Título",
-          "title_placeholder": "Padrão para o nome do pré-ajuste",
-          "resolution": "Resolução",
-          "submit": "Gerar highlights"
-      },
-      "presets": {
-          "multikills": "Multi-kills",
-          "multikills_hint": "Cada rodada com 2+ abates, cortada para a ação",
-          "best_round": "Melhor rodada",
-          "best_round_hint": "Rodada única com mais abates",
-          "knife": "Abates de faca",
-          "knife_hint": "Cada abate de faca com 5s de introdução",
-          "recap": "Resumo da partida",
-          "recap_hint": "Cada rodada em que o jogador conseguiu pelo menos um abate"
+    },
+    "render_queue": {
+      "in_flight": "Em andamento",
+      "cancel": "Cancelar",
+      "render": "Renderizar",
+      "upload": "Enviar",
+      "recently_finished": "Finalizado recentemente"
+    },
+    "visibility_section": "Visibilidade",
+    "create_dialog": {
+      "title": "Clipe automático",
+      "description": "Escolha um jogador e um pré-ajuste — o servidor analisa os abates da partida, monta os segmentos e renderiza um mp4.",
+      "player": "Jogador",
+      "pick_player_placeholder": "Escolha um jogador para destacar",
+      "no_players_yet": "Nenhum jogador encontrado ainda — aguarde a demo começar a rodar e tente novamente.",
+      "other_group": "Outros",
+      "preset": "Pré-ajuste",
+      "title_label": "Título",
+      "title_placeholder": "Padrão para o nome do pré-ajuste",
+      "resolution": "Resolução",
+      "submit": "Gerar highlights"
+    },
+    "presets": {
+      "multikills": "Multi-kills",
+      "multikills_hint": "Cada rodada com 2+ abates, cortada para a ação",
+      "best_round": "Melhor rodada",
+      "best_round_hint": "Rodada única com mais abates",
+      "knife": "Abates de faca",
+      "knife_hint": "Cada abate de faca com 5s de introdução",
+      "recap": "Resumo da partida",
+      "recap_hint": "Cada rodada em que o jogador conseguiu pelo menos um abate"
     },
     "render_progress": {
       "render": "Renderizar",
@@ -3416,7 +3483,7 @@
       "close": "Fechar"
     },
     "ct": "(CT)",
-        "t": "(TR)",
+    "t": "(TR)",
     "untitled_clip": "Clip sem título",
     "delete_dialog": {
       "title": "Excluir este clip?",
@@ -3437,12 +3504,12 @@
     "now_playing": "Reproduzindo agora",
     "selected": "Selecionado",
     "visibility": {
-        "public": "Público",
-        "public_hint": "Listados no feed de highlights",
-        "unlisted": "Não listado",
-        "unlisted_hint": "Oculto dos feeds — qualquer pessoa com o link pode visualizar",
-        "private": "Privado",
-        "private_hint": "Oculto dos feeds — a URL do arquivo ainda reproduz se compartilhada"
+      "public": "Público",
+      "public_hint": "Listados no feed de highlights",
+      "unlisted": "Não listado",
+      "unlisted_hint": "Oculto dos feeds — qualquer pessoa com o link pode visualizar",
+      "private": "Privado",
+      "private_hint": "Oculto dos feeds — a URL do arquivo ainda reproduz se compartilhada"
     }
   },
   "time_ago": {


### PR DESCRIPTION
…ara ultima versão, alteração da desc## 📌 Detalhes da Tradução (pt-BR)

### Alterações realizadas
- **59 chaves traduzidas**.
- **4 chaves reformuladas** para maior clareza e consistência.
- Corrigida a tradução equivocada do termo **"equipes"**, anteriormente grafado como **"equiopes"**.
- Ajustada a tradução de **"Adicionar como amigo"** para **"Adicionar aos amigos"**, privilegiando a lógica do sistema de amizade do matchmaking.

---

## 📌 Translation Details (EN)

### Changes made
- **59 keys translated**.
- **4 keys reformulated** for better clarity and consistency.
- Fixed the incorrect translation of the term **"equipes"**, previously misspelled as **"equiopes"**.
- Adjusted the translation of **"Add as friend"** to **"Add to friends"**, aligning with the logic of the matchmaking friendship system.

até #388