### PR TITLE
bug: fix clip visibility controls (menu hidden in modal, chip stale until refresh)

### DIFF
--- a/components/clips/ClipDetailModal.vue
+++ b/components/clips/ClipDetailModal.vue
@@ -163,6 +163,11 @@ async function setVisibility(v: Visibility) {
         ],
       } as any),
     });
+    // The match_clips subscription does not always echo this change back
+    // promptly, so reflect it locally to keep the chip in sync.
+    if (clip.value) {
+      clip.value = { ...clip.value, visibility: v };
+    }
     visPopoverOpen.value = false;
   } catch (e) {
     console.error("[clip-modal] visibility toggle failed:", e);

--- a/components/clips/ClipDetailModal.vue
+++ b/components/clips/ClipDetailModal.vue
@@ -531,7 +531,7 @@ onMounted(() => {
               </span>
               {{ clip.visibility }}
             </PopoverTrigger>
-            <PopoverContent class="w-64 p-1" align="end">
+            <PopoverContent class="z-[70] w-64 p-1" align="end">
               <div
                 class="px-2 py-1.5 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
               >

--- a/components/clips/HighlightCard.vue
+++ b/components/clips/HighlightCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   Film,
@@ -104,15 +104,28 @@ const VISIBILITY_OPTIONS = computed<
 const saving = ref(false);
 const visPopoverOpen = ref(false);
 
+// The highlights/match lists load clips with a network-only query, so the
+// updateClip mutation (which returns only { success }) never refreshes this
+// card's prop. Track the displayed visibility locally, sync it when the prop
+// changes, and set it on a successful toggle so the chip reflects the new
+// state immediately instead of only after a page refresh.
+const visibility = ref<Visibility>(props.clip.visibility as Visibility);
+watch(
+  () => props.clip.visibility,
+  (v) => {
+    visibility.value = v as Visibility;
+  },
+);
+
 const currentVisibilityMeta = computed(() => {
   return (
-    VISIBILITY_OPTIONS.value.find((o) => o.value === props.clip.visibility) ??
+    VISIBILITY_OPTIONS.value.find((o) => o.value === visibility.value) ??
     VISIBILITY_OPTIONS.value[2]
   );
 });
 
 async function setVisibility(v: Visibility) {
-  if (saving.value || props.clip.visibility === v) {
+  if (saving.value || visibility.value === v) {
     visPopoverOpen.value = false;
     return;
   }
@@ -126,6 +139,7 @@ async function setVisibility(v: Visibility) {
         ],
       } as any),
     });
+    visibility.value = v;
     visPopoverOpen.value = false;
   } catch (e) {
     console.error("[highlight-card] visibility toggle failed:", e);
@@ -199,20 +213,20 @@ async function setVisibility(v: Visibility) {
               class="inline-flex h-7 items-center gap-1 rounded-full bg-black/75 pl-1.5 pr-2 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/90 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer"
               :aria-label="
                 $t('ui_extras.visibility_change_hint', {
-                  value: clip.visibility,
+                  value: visibility,
                 })
               "
               :title="
-                $t('ui_extras.visibility_label', { value: clip.visibility })
+                $t('ui_extras.visibility_label', { value: visibility })
               "
               @click.stop
             >
               <span
                 class="inline-flex h-4 w-4 items-center justify-center rounded-full"
                 :class="
-                  clip.visibility === 'public'
+                  visibility === 'public'
                     ? 'bg-emerald-400/20 text-emerald-300'
-                    : clip.visibility === 'unlisted'
+                    : visibility === 'unlisted'
                       ? 'bg-amber-400/20 text-amber-300'
                       : 'bg-white/10 text-white/80'
                 "
@@ -241,7 +255,7 @@ async function setVisibility(v: Visibility) {
                 :key="opt.value"
                 type="button"
                 class="w-full text-left flex items-start gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted/60 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-                :class="clip.visibility === opt.value ? 'bg-muted/40' : ''"
+                :class="visibility === opt.value ? 'bg-muted/40' : ''"
                 :disabled="saving"
                 @click="setVisibility(opt.value)"
               >
@@ -261,7 +275,7 @@ async function setVisibility(v: Visibility) {
                   <span class="flex items-center gap-1.5 font-medium">
                     {{ opt.label }}
                     <Check
-                      v-if="clip.visibility === opt.value"
+                      v-if="visibility === opt.value"
                       class="h-3 w-3 text-[hsl(var(--tac-amber))]"
                     />
                   </span>
@@ -278,18 +292,18 @@ async function setVisibility(v: Visibility) {
             v-else
             class="inline-flex h-7 items-center gap-1 rounded-full bg-black/75 pl-1.5 pr-2 text-white/90 backdrop-blur-sm pointer-events-none"
             :title="
-              $t('ui_extras.visibility_label', { value: clip.visibility })
+              $t('ui_extras.visibility_label', { value: visibility })
             "
             :aria-label="
-              $t('ui_extras.visibility_label', { value: clip.visibility })
+              $t('ui_extras.visibility_label', { value: visibility })
             "
           >
             <span
               class="inline-flex h-4 w-4 items-center justify-center rounded-full"
               :class="
-                clip.visibility === 'public'
+                visibility === 'public'
                   ? 'bg-emerald-400/20 text-emerald-300'
-                  : clip.visibility === 'unlisted'
+                  : visibility === 'unlisted'
                     ? 'bg-amber-400/20 text-amber-300'
                     : 'bg-white/10 text-white/80'
               "


### PR DESCRIPTION
## Problems

Two issues with the per-clip visibility control:

1. **Menu does not open in the clip modal.** Clicking the visibility chip in the clip detail modal did nothing, no menu appeared.
2. **Chip does not reflect the new state until a page refresh.** Changing visibility from a highlight card (or the modal) left the chip showing the old value until the page was reloaded.

## Root causes

1. `PopoverContent` defaults to `z-50` and portals to `<body>`, but the clip modal's `DialogOverlay` and `DialogContent` are `z-[60]` (with an 85% opaque overlay). The popover menu opened behind the overlay, invisible and unclickable.
2. The `updateClip` mutation returns only `{ success }`. The `HighlightCard` pill renders `props.clip.visibility`, which comes from the highlights/match list query (`fetchPolicy: network-only`); nothing refetches it after the mutation, so it stayed stale until a refresh. The modal relied on the `match_clips` subscription to echo the change back, which does not always arrive promptly.

## Fixes

1. Raise the modal's visibility `PopoverContent` to `z-[70]` so it stacks above the dialog. `tailwind-merge` lets the per-usage class override the component default `z-50`, so no shared component or other popover is affected.
2. Reflect the change locally on success:
   - `HighlightCard`: track the displayed visibility in a local ref, seed it from the prop, sync on prop change, and set it when the toggle succeeds.
   - `ClipDetailModal`: after the mutation, update the local `clip` so the header chip updates immediately (the subscription remains the source of truth for external changes).

## Verification

- Open a clip modal as owner/admin and click the visibility chip: the menu now appears above the modal and options are clickable.
- Change visibility from a highlight card pill and from the modal chip: the chip updates immediately, no refresh needed.
- Non-owners/non-admins still see the read-only chip.

## Note

This pairs with the API-side fix (5stackgg/api#278) that lets anonymous viewers read `unlisted` clips. This PR is the UI side: making the visibility control usable and its state immediate.
