### PR TITLE
Add 2D replay pathing overlay

### DIFF
--- a/components/match/ReplayViewer.vue
+++ b/components/match/ReplayViewer.vue
@@ -26,6 +26,7 @@ import {
   Hash,
   Crosshair,
   Settings2,
+  Route,
 } from "lucide-vue-next";
 import { Kbd } from "~/components/ui/kbd";
 import {
@@ -134,6 +135,7 @@ type TimerState = {
   phase: TimerPhase;
   secondsRemaining: number;
 };
+type PathingMode = "off" | "progress" | "round";
 
 type Shot = {
   round: number;
@@ -1107,6 +1109,98 @@ function project(p: { x: number; y: number; z?: number }) {
   return projectRaw(p);
 }
 
+const PATH_MIN_SCREEN_DIST = 4;
+const PATH_MAX_WORLD_JUMP = 1800;
+const PATH_MAX_TICK_GAP_SEC = 2.5;
+
+type RadarPathSegment = {
+  key: string;
+  team: string | null;
+  d: string;
+  focused: boolean;
+};
+
+function pathSegmentToD(points: Array<{ x: number; y: number }>): string {
+  return points
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`)
+    .join(" ");
+}
+
+const playerPathSegments = computed<RadarPathSegment[]>(() => {
+  if (pathingMode.value === "off") return [];
+  const cursor =
+    pathingMode.value === "progress" ? smoothCurrentTick.value : Infinity;
+  const maxTickGap = Math.max(
+    1,
+    Math.round((props.tickRate || 64) * PATH_MAX_TICK_GAP_SEC),
+  );
+  const out: RadarPathSegment[] = [];
+
+  for (const [sid, samples] of positionsByPlayer.value) {
+    const focused = focusedPlayerId.value === sid;
+    let team: string | null = null;
+    let segment: Array<{ x: number; y: number }> = [];
+    let lastSample: Position | null = null;
+    let lastPoint: { x: number; y: number } | null = null;
+    let segmentIdx = 0;
+
+    const flush = () => {
+      if (segment.length < 2) {
+        segment = [];
+        lastPoint = null;
+        return;
+      }
+      out.push({
+        key: `${sid}-${segmentIdx++}`,
+        team,
+        d: pathSegmentToD(segment),
+        focused,
+      });
+      segment = [];
+      lastPoint = null;
+    };
+
+    for (const sample of samples) {
+      if (sample.tick > cursor) break;
+      if (!sample.alive) {
+        flush();
+        lastSample = null;
+        continue;
+      }
+      team ??= sample.attacker_team;
+      if (lastSample) {
+        const dx = sample.x - lastSample.x;
+        const dy = sample.y - lastSample.y;
+        const jump = dx * dx + dy * dy;
+        if (
+          sample.tick - lastSample.tick > maxTickGap ||
+          jump > PATH_MAX_WORLD_JUMP * PATH_MAX_WORLD_JUMP
+        ) {
+          flush();
+        }
+      }
+
+      const point = project(sample);
+      if (
+        lastPoint &&
+        segment.length > 1 &&
+        (point.x - lastPoint.x) * (point.x - lastPoint.x) +
+          (point.y - lastPoint.y) * (point.y - lastPoint.y) <
+          PATH_MIN_SCREEN_DIST * PATH_MIN_SCREEN_DIST
+      ) {
+        lastSample = sample;
+        continue;
+      }
+      segment.push(point);
+      lastPoint = point;
+      lastSample = sample;
+    }
+    flush();
+  }
+
+  return out;
+});
+
 let rafHandle: number | null = null;
 let lastFrameTs = 0;
 
@@ -1378,6 +1472,24 @@ const showC4 = persistedBool("5s.replay.show_c4", true);
 const showDefuser = persistedBool("5s.replay.show_defuser", true);
 const showGroundBomb = persistedBool("5s.replay.show_ground_bomb", true);
 const showGroundKits = persistedBool("5s.replay.show_ground_kits", true);
+const REPLAY_PATHING_PREF_KEY = "5s.replay.pathing_mode";
+const pathingMode = ref<PathingMode>("off");
+if (typeof window !== "undefined") {
+  try {
+    const pref = localStorage.getItem(REPLAY_PATHING_PREF_KEY);
+    if (pref === "progress" || pref === "round") pathingMode.value = pref;
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+watch(pathingMode, (v) => {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(REPLAY_PATHING_PREF_KEY, v);
+  } catch {
+    /* private browsing or storage full */
+  }
+});
 
 const layoutRootEl = ref<HTMLElement | null>(null);
 // playbarRowEl is referenced from the in-radar overlay; kept here so
@@ -2025,6 +2137,38 @@ function openReplayPopout() {
                 }}
               </TooltipContent>
             </Tooltip>
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <button
+                  type="button"
+                  class="inline-flex items-center justify-center w-10 h-10 border bg-[hsl(var(--card)/0.85)] transition-colors backdrop-blur-sm"
+                  :class="
+                    pathingMode === 'off'
+                      ? 'border-[hsl(var(--tac-amber)/0.35)] text-muted-foreground hover:border-[hsl(var(--tac-amber)/0.7)] hover:text-[hsl(var(--tac-amber))]'
+                      : 'border-[hsl(var(--tac-amber))] bg-[hsl(var(--tac-amber)/0.18)] text-[hsl(var(--tac-amber))]'
+                  "
+                  @click="
+                    pathingMode =
+                      pathingMode === 'off'
+                        ? 'progress'
+                        : pathingMode === 'progress'
+                          ? 'round'
+                          : 'off'
+                  "
+                >
+                  <Route class="w-5 h-5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {{
+                  pathingMode === "off"
+                    ? t("match.replay.pathing_off")
+                    : pathingMode === "progress"
+                      ? t("match.replay.pathing_progress")
+                      : t("match.replay.pathing_round")
+                }}
+              </TooltipContent>
+            </Tooltip>
             <Popover>
               <PopoverTrigger as-child>
                 <button
@@ -2080,6 +2224,44 @@ function openReplayPopout() {
                     class="accent-[hsl(var(--tac-amber))]"
                   />
                   <span>{{ $t("match.replay.overlay_ground_kits") }}</span>
+                </label>
+                <div
+                  class="mt-2 px-1 py-1 text-[0.55rem] tracking-[0.22em] uppercase text-muted-foreground border-t border-border/60 pt-2"
+                >
+                  {{ t("match.replay.pathing") }}
+                </div>
+                <label
+                  class="flex items-center gap-2 px-2 py-1.5 rounded-sm hover:bg-muted/40 cursor-pointer"
+                >
+                  <input
+                    v-model="pathingMode"
+                    type="radio"
+                    value="off"
+                    class="accent-[hsl(var(--tac-amber))]"
+                  />
+                  <span>{{ t("match.replay.pathing_off") }}</span>
+                </label>
+                <label
+                  class="flex items-center gap-2 px-2 py-1.5 rounded-sm hover:bg-muted/40 cursor-pointer"
+                >
+                  <input
+                    v-model="pathingMode"
+                    type="radio"
+                    value="progress"
+                    class="accent-[hsl(var(--tac-amber))]"
+                  />
+                  <span>{{ t("match.replay.pathing_progress") }}</span>
+                </label>
+                <label
+                  class="flex items-center gap-2 px-2 py-1.5 rounded-sm hover:bg-muted/40 cursor-pointer"
+                >
+                  <input
+                    v-model="pathingMode"
+                    type="radio"
+                    value="round"
+                    class="accent-[hsl(var(--tac-amber))]"
+                  />
+                  <span>{{ t("match.replay.pathing_round") }}</span>
                 </label>
               </PopoverContent>
             </Popover>
@@ -2270,6 +2452,30 @@ function openReplayPopout() {
                 <circle cx="0" cy="0" r="12" />
               </clipPath>
             </defs>
+
+            <g
+              v-if="playerPathSegments.length"
+              class="pointer-events-none"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <g v-for="path of playerPathSegments" :key="path.key">
+                <path
+                  :d="path.d"
+                  stroke="rgba(0,0,0,0.55)"
+                  :stroke-width="path.focused ? 8 : 5.5"
+                  stroke-opacity="0.42"
+                />
+                <path
+                  :d="path.d"
+                  :stroke="colorFor(path.team)"
+                  :stroke-width="path.focused ? 4.2 : 2.4"
+                  :stroke-opacity="path.focused ? 0.9 : 0.5"
+                  :stroke-dasharray="path.focused ? 'none' : '10 8'"
+                />
+              </g>
+            </g>
 
             <!-- Detonated grenades — animated SVG primitives.
                Smoke = pulsing gray disc with team-tinted ring,

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3034,7 +3034,11 @@
       "overlay_c4": "C4 carrier",
       "overlay_defuser": "Defuse kits",
       "overlay_ground_bomb": "Dropped / planted bomb",
-      "overlay_ground_kits": "Dropped kits"
+      "overlay_ground_kits": "Dropped kits",
+      "pathing": "Pathing",
+      "pathing_off": "Pathing off",
+      "pathing_progress": "Pathing to current tick",
+      "pathing_round": "Full round pathing"
     },
     "player_details_panel": {
       "stats_unavailable": "Stats unavailable for this match.",

--- a/i18n/locales/pt_BR.json
+++ b/i18n/locales/pt_BR.json
@@ -2969,7 +2969,11 @@
       "overlay_c4": "Portador da C4",
       "overlay_defuser": "Kits de desarme",
       "overlay_ground_bomb": "Bomba dropada / plantada",
-      "overlay_ground_kits": "Kits dropados"
+      "overlay_ground_kits": "Kits dropados",
+      "pathing": "Rotas",
+      "pathing_off": "Rotas desativadas",
+      "pathing_progress": "Rotas ate o tick atual",
+      "pathing_round": "Rotas da rodada completa"
     },
     "player_details_panel": {
       "stats_unavailable": "Estatísticas indisponíveis para esta partida.",


### PR DESCRIPTION
## Summary

Adds a 2D replay pathing overlay for issue 5stackgg/5stack-panel#506.

- Adds a route/pathing control to the replay viewer.
- Supports pathing to the current tick and full-round pathing.
- Draws team-colored player route segments behind the existing replay markers, with focused player emphasis.
- Persists the selected pathing mode in local storage.
- Adds English and Portuguese replay labels.

Refs 5stackgg/5stack-panel#506
Refs https://github.com/5stackgg/5stack-panel/issues/506#issuecomment-4617809260

## Validation

- `corepack yarn check-translations`
- `corepack yarn build`