### PR TITLE
feature: beta release channel selector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches:
       - "main"
+      - "beta"
   workflow_dispatch:
 
 concurrency:
-  group: build
+  group: build-${{ github.ref_name }}
   cancel-in-progress: true
+
+env:
+  CHANNEL: ${{ github.ref_name == 'main' && 'latest' || 'beta' }}
+  TAG_PREFIX: ${{ github.ref_name != 'main' && 'beta-' || '' }}
 
 jobs:
   build-amd64:
@@ -31,11 +36,11 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:buildcache-amd64,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:buildcache-${{ env.TAG_PREFIX }}amd64
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:buildcache-${{ env.TAG_PREFIX }}amd64,mode=max
           tags: |
-            ghcr.io/${{ github.repository_owner }}/web:latest-amd64
-            ghcr.io/${{ github.repository_owner }}/web:${{ github.sha }}-amd64
+            ghcr.io/${{ github.repository_owner }}/web:${{ env.CHANNEL }}-amd64
+            ghcr.io/${{ github.repository_owner }}/web:${{ env.TAG_PREFIX }}${{ github.sha }}-amd64
   build-arm64:
     runs-on: ubuntu-24.04-arm
     steps:
@@ -56,14 +61,16 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/arm64
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:buildcache-arm64
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:buildcache-arm64,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:buildcache-${{ env.TAG_PREFIX }}arm64
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/web:buildcache-${{ env.TAG_PREFIX }}arm64,mode=max
           tags: |
-            ghcr.io/${{ github.repository_owner }}/web:latest-arm64
-            ghcr.io/${{ github.repository_owner }}/web:${{ github.sha }}-arm64
+            ghcr.io/${{ github.repository_owner }}/web:${{ env.CHANNEL }}-arm64
+            ghcr.io/${{ github.repository_owner }}/web:${{ env.TAG_PREFIX }}${{ github.sha }}-arm64
   merge:
     needs: [build-amd64, build-arm64]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v3
@@ -73,16 +80,44 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
         run: |
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/web:latest \
-            ghcr.io/${{ github.repository_owner }}/web:latest-amd64 \
-            ghcr.io/${{ github.repository_owner }}/web:latest-arm64
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/web:${{ github.sha }} \
-            ghcr.io/${{ github.repository_owner }}/web:${{ github.sha }}-amd64 \
-            ghcr.io/${{ github.repository_owner }}/web:${{ github.sha }}-arm64
-      - name: Delete Package Versions
-        uses: actions/delete-package-versions@v5
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/web:${{ env.CHANNEL }} \
+            ghcr.io/${{ github.repository_owner }}/web:${{ env.CHANNEL }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/web:${{ env.CHANNEL }}-arm64
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/web:${{ env.TAG_PREFIX }}${{ github.sha }} \
+            ghcr.io/${{ github.repository_owner }}/web:${{ env.TAG_PREFIX }}${{ github.sha }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/web:${{ env.TAG_PREFIX }}${{ github.sha }}-arm64
+      - name: Prune old images for channel
+        uses: actions/github-script@v7
         with:
-          package-name: web
-          package-type: container
-          min-versions-to-keep: 9
-          ignore-versions: '^buildcache-*'
+          script: |
+            const channel = context.ref === 'refs/heads/main' ? 'main' : 'beta';
+            const keep = 9;
+            const owner = context.repo.owner;
+            const pkg = 'web';
+            const isBuildcache = (t) => t.startsWith('buildcache');
+            const isBeta = (t) => t === 'beta' || t.startsWith('beta-');
+            const { data: ownerInfo } = await github.rest.users.getByUsername({ username: owner });
+            const isOrg = ownerInfo.type === 'Organization';
+            const listFn = isOrg
+              ? github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg
+              : github.rest.packages.getAllPackageVersionsForPackageOwnedByUser;
+            const listArgs = isOrg
+              ? { package_type: 'container', package_name: pkg, org: owner, per_page: 100 }
+              : { package_type: 'container', package_name: pkg, username: owner, per_page: 100 };
+            const versions = await github.paginate(listFn, listArgs);
+            const inChannel = versions.filter((v) => {
+              const tags = v.metadata?.container?.tags || [];
+              if (tags.length === 0) return false;
+              if (tags.some(isBuildcache)) return false;
+              const beta = tags.some(isBeta);
+              return channel === 'beta' ? beta : !beta;
+            });
+            inChannel.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            const toDelete = inChannel.slice(keep);
+            for (const v of toDelete) {
+              await (isOrg
+                ? github.rest.packages.deletePackageVersionForOrg({ package_type: 'container', package_name: pkg, org: owner, package_version_id: v.id })
+                : github.rest.packages.deletePackageVersionForUser({ package_type: 'container', package_name: pkg, username: owner, package_version_id: v.id }));
+              core.info(`deleted ${pkg} ${v.id} [${(v.metadata?.container?.tags || []).join(', ')}]`);
+            }
+            core.info(`channel=${channel} candidates=${inChannel.length} deleted=${toDelete.length}`);

--- a/composables/useSettingsNav.ts
+++ b/composables/useSettingsNav.ts
@@ -79,6 +79,10 @@ export const SETTINGS_NAV_GROUPS: SettingsNavGroup[] = [
         labelKey: "pages.settings.application.servers.title",
       },
       {
+        path: "/settings/application/release-channel",
+        labelKey: "pages.settings.application.release_channel.title",
+      },
+      {
         path: "/settings/application/telemetry",
         labelKey: "pages.settings.application.telemetry.title",
       },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1772,6 +1772,17 @@
                     "reserved_disk_space_existing_gb_description": "Minimum disk space in GB required when CS2 is already installed on the node. Set to 0 to disable.",
                     "update_cpu_pinning": "CPU Pinning updated"
                 },
+                "release_channel": {
+                    "title": "Release Channel",
+                    "section": "Release Channel",
+                    "description": "Choose which release channel this install tracks. Latest is the stable channel; Beta receives pre-release builds early.",
+                    "latest": "Latest",
+                    "beta": "Beta",
+                    "beta_warning": "Beta is a pre-release channel and may be unstable. Services will be updated to pre-release builds as they become available.",
+                    "service_status": "Service Status",
+                    "fell_back": "beta not available yet — using latest",
+                    "updated": "Release channel updated"
+                },
                 "highlights": {
                     "title": "Highlights",
                     "updated": "Updated highlight settings"

--- a/pages/settings/application/release-channel.vue
+++ b/pages/settings/application/release-channel.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import { AlertTriangle } from "lucide-vue-next";
+import PageTransition from "~/components/ui/transitions/PageTransition.vue";
+import SettingsPage from "~/components/settings/SettingsPage.vue";
+import SettingsSection from "~/components/settings/SettingsSection.vue";
+import AnimatedFilters from "~/components/common/AnimatedFilters.vue";
+
+definePageMeta({
+  middleware: "admin",
+});
+</script>
+
+<template>
+  <SettingsPage>
+    <PageTransition :delay="0">
+      <div class="space-y-6">
+        <SettingsSection
+          id="release-channel"
+          :title="$t('pages.settings.application.release_channel.section')"
+          :description="
+            $t('pages.settings.application.release_channel.description')
+          "
+        >
+          <AnimatedFilters
+            :model-value="currentChannel"
+            :options="channelOptions"
+            square
+            size="lg"
+            @update:model-value="selectChannel"
+          />
+
+          <div
+            v-if="onBeta"
+            class="flex items-start gap-3 rounded-lg border border-[hsl(var(--tac-amber))]/40 bg-[hsl(var(--tac-amber))]/10 p-4 text-sm"
+          >
+            <AlertTriangle
+              class="h-5 w-5 mt-0.5 flex-shrink-0 text-[hsl(var(--tac-amber))]"
+            />
+            <p class="text-muted-foreground">
+              {{ $t("pages.settings.application.release_channel.beta_warning") }}
+            </p>
+          </div>
+
+          <div v-if="onBeta && serviceStatuses.length > 0" class="space-y-3">
+            <h4
+              class="text-sm font-semibold uppercase tracking-wider text-foreground"
+            >
+              {{ $t("pages.settings.application.release_channel.service_status") }}
+            </h4>
+            <ul class="space-y-2">
+              <li
+                v-for="service in serviceStatuses"
+                :key="service.service"
+                class="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/30 px-4 py-2 text-sm"
+              >
+                <span class="font-mono">{{ service.service }}</span>
+                <span
+                  v-if="service.fellBack"
+                  class="text-[hsl(var(--tac-amber))]"
+                >
+                  {{
+                    $t("pages.settings.application.release_channel.fell_back")
+                  }}
+                </span>
+                <span v-else class="capitalize text-muted-foreground">{{
+                  service.tag
+                }}</span>
+              </li>
+            </ul>
+          </div>
+        </SettingsSection>
+      </div>
+    </PageTransition>
+  </SettingsPage>
+</template>
+
+<script lang="ts">
+import { generateMutation } from "~/graphql/graphqlGen";
+import { toast } from "@/components/ui/toast";
+
+interface ReleaseChannelServiceStatus {
+  service: string;
+  tag: string;
+  fellBack: boolean;
+}
+
+export default {
+  data() {
+    return {
+      submitting: false,
+    };
+  },
+  methods: {
+    async selectChannel(channel: string) {
+      if (this.submitting || channel === this.currentChannel) {
+        return;
+      }
+      this.submitting = true;
+      try {
+        await (this as any).$apollo.mutate({
+          mutation: generateMutation({
+            setReleaseChannel: [
+              {
+                channel,
+              },
+              {
+                success: true,
+              },
+            ],
+          }),
+        });
+
+        toast({
+          title: this.$t(
+            "pages.settings.application.release_channel.updated",
+          ) as string,
+        });
+      } finally {
+        this.submitting = false;
+      }
+    },
+  },
+  computed: {
+    settings() {
+      return useApplicationSettingsStore().settings;
+    },
+    currentChannel(): string {
+      const value = this.settings.find(
+        (setting: { name: string; value: string | null }) =>
+          setting.name === "release_channel",
+      )?.value;
+
+      return value === "beta" ? "beta" : "latest";
+    },
+    onBeta(): boolean {
+      return this.currentChannel === "beta";
+    },
+    channelOptions() {
+      return [
+        {
+          key: "latest",
+          label: this.$t("pages.settings.application.release_channel.latest"),
+          disabled: this.submitting,
+        },
+        {
+          key: "beta",
+          label: this.$t("pages.settings.application.release_channel.beta"),
+          disabled: this.submitting,
+        },
+      ];
+    },
+    releaseChannelStatus(): {
+      channel: string;
+      services: ReleaseChannelServiceStatus[];
+    } | null {
+      const raw = this.settings.find(
+        (setting: { name: string; value: string | null }) =>
+          setting.name === "release_channel_status",
+      )?.value;
+
+      if (!raw) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return null;
+      }
+    },
+    serviceStatuses(): ReleaseChannelServiceStatus[] {
+      return this.releaseChannelStatus?.services ?? [];
+    },
+  },
+};
+</script>


### PR DESCRIPTION
Part of the cross-repo beta release channel feature. Pairs with the api PR (release channel setting, `setReleaseChannel` action, image reconcile).

## Changes
- New admin-only settings page `settings/application/release-channel` (Infrastructure nav group): `Latest | Beta` segmented selector (`AnimatedFilters`, square variant) calling the `setReleaseChannel` action, with a submitting guard against double-fires
- Amber pre-release warning while on beta, plus per-service status parsed from the `release_channel_status` setting — services whose beta image does not exist yet show "beta not available — using latest"
- Settings are non-`public.`-prefixed, so only admins receive them via the settings subscription; the page itself is gated by the `admin` middleware
- CI: build the `beta` branch into `beta`/`beta-<sha>` tags with per-channel buildcache, and a tag-based prune that only touches the channel being built (replaces `delete-package-versions`, whose `ignore-versions` matches digests rather than tags)

## Depends on
- api PR for the `setReleaseChannel` hasura action — run codegen after the hasura metadata is applied so the generated client picks up the mutation (the call mirrors `restartService`/`updateServices`, so no code change is needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)