### PR TITLE
fix(web): make Create Lobby button follow branding tokens

### DIFF
--- a/layouts/components/MatchLobbies.vue
+++ b/layouts/components/MatchLobbies.vue
@@ -88,9 +88,11 @@ const isElevatedUser = computed(() =>
       class="relative group h-12 overflow-hidden rounded bg-transparent px-5 text-[hsl(var(--tac-amber))] shadow-lg hover:bg-transparent hover:text-[hsl(var(--tac-amber))] hover:shadow transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--tac-amber))]"
     >
       <span
-        class="absolute inset-0 rounded p-[1.5px] bg-[linear-gradient(135deg,hsl(40_58%_60%)_0%,hsl(33_62%_55%)_50%,hsl(24_56%_52%)_100%)]"
+        class="absolute inset-0 rounded p-[1.5px] bg-[linear-gradient(135deg,var(--tac-amber-cta-from)_0%,hsl(var(--tac-amber))_50%,var(--tac-amber-cta-to)_100%)]"
       >
-        <span class="block h-full w-full rounded-[2.5px] bg-zinc-900/90"></span>
+        <span
+          class="block h-full w-full rounded-[2.5px] bg-[hsl(var(--topnav-background))]"
+        ></span>
       </span>
 
       <span


### PR DESCRIPTION
## Problem

The top-nav **Create Lobby** button rendered with mismatched colors under a customized theme: an amber/gold border with brand-colored (e.g. purple) text. The cause was that two of the button's colors were hardcoded while the rest already followed branding:

- **Border**: hardcoded amber gradient `hsl(40 58% 60%) / hsl(33 62% 55%) / hsl(24 56% 52%)`
- **Interior fill**: hardcoded `bg-zinc-900/90`
- Text + focus ring: already used `--tac-amber`

So when the "Tactical Accent" branding color (`--tac-amber`) is set to anything other than the default amber, the text takes the brand hue while the border stays amber, and the dark interior fill would break on a light top-nav.

## Fix

`layouts/components/MatchLobbies.vue`:

- **Border** now uses the branding-derived gradient `var(--tac-amber-cta-from) / hsl(var(--tac-amber)) / var(--tac-amber-cta-to)`, the same expression used by the sibling Play button and by `.tac-amber-cta` in `assets/css/tailwind.css`. Those CTA endpoints are `color-mix`ed from `--tac-amber`, so the whole gradient follows branding.
- **Interior fill** now uses `hsl(var(--topnav-background))` so the outline reads correctly on the nav surface in both light and dark mode.

The button now follows the Tactical Accent branding color end to end (border, text, ring, hover tint), so a rebrand no longer produces the amber-border / brand-text mismatch.

## Note

In the default amber theme the border becomes slightly brighter and more saturated than before, because it now matches the Play button's CTA gradient rather than the old muted one. This is intentional: the two buttons share the same header slot and should look consistent.

## Testing

CSS-only change (Tailwind arbitrary values), using the same pattern as the working Play button. Not run in-app locally; recommend a quick visual check of the Create Lobby button under the default amber theme and a custom Tactical Accent color, in both light and dark mode.
