### PR TITLE
bug: leaderboard source filter, ban expiry countdown, sanction links

### DIFF
--- a/components/PlayerSanctions.vue
+++ b/components/PlayerSanctions.vue
@@ -330,16 +330,22 @@ import { fromDate, toCalendarDate } from "@internationalized/date";
               >
                 <div class="flex items-center justify-between py-2">
                   <div class="flex flex-col gap-1 flex-1">
+                    <!-- Records predating match_id have nothing to link to, so
+                         they render as plain text rather than a dead link. -->
                     <NuxtLink
+                      v-if="abandonedMatch.match_id"
                       :to="{
                         name: 'matches-id',
-                        params: { id: abandonedMatch.id },
+                        params: { id: abandonedMatch.match_id },
                       }"
                       class="text-sm font-medium hover:underline text-primary"
                     >
                       {{ $t("player.sanctions.match") }}
-                      {{ abandonedMatch.id.slice(0, 8) }}
+                      {{ abandonedMatch.match_id.slice(0, 8) }}
                     </NuxtLink>
+                    <span v-else class="text-sm font-medium">
+                      {{ $t("player.sanctions.match") }}
+                    </span>
                     <div
                       class="text-xs text-muted-foreground flex items-center gap-2"
                     >
@@ -631,6 +637,7 @@ export default {
               id: true,
               steam_id: true,
               abandoned_at: true,
+              match_id: true,
             },
           ],
         }),

--- a/components/PlayerSearch.vue
+++ b/components/PlayerSearch.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { CaretSortIcon } from "@radix-icons/vue";
-import { Switch } from "~/components/ui/switch";
+import { Search } from "lucide-vue-next";
 import { Drawer, DrawerContent, DrawerTitle } from "~/components/ui/drawer";
+import FilterRail from "~/components/common/FilterRail.vue";
+import FilterChip from "~/components/common/FilterChip.vue";
 import PlayerDisplay from "~/components/PlayerDisplay.vue";
 import PlayerSearchRow from "~/components/PlayerSearchRow.vue";
 import { useMediaQuery } from "@vueuse/core";
@@ -141,33 +143,43 @@ const { height: viewportHeight } = useVisualViewport();
           </template>
         </div>
 
-        <div class="flex items-center justify-between p-4 border-t">
-          <input
-            ref="mobileSearchInput"
-            v-model="query"
-            :placeholder="$t('player.search.placeholder')"
-            type="search"
-            inputmode="search"
-            enterkeyhint="search"
-            autocomplete="off"
-            autocorrect="off"
-            autocapitalize="off"
-            spellcheck="false"
-            class="flex-1 bg-transparent outline-none text-base"
-            @input="
-              (e: Event) =>
-                debouncedSearch((e.target as HTMLInputElement).value)
-            "
-            @keydown="onKeydown"
-          />
-          <div class="flex items-center gap-2 ml-4">
-            <Switch
-              class="text-sm text-muted-foreground cursor-pointer flex items-center gap-2"
-              :model-value="onlineOnly"
-              @click="toggleOnlineOnly"
+        <div class="flex flex-col gap-2.5 p-4 border-t">
+          <div class="relative">
+            <Search
+              class="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
             />
-            {{ $t("common.online") }}
+            <input
+              ref="mobileSearchInput"
+              v-model="query"
+              :placeholder="$t('player.search.placeholder')"
+              type="search"
+              inputmode="search"
+              enterkeyhint="search"
+              autocomplete="off"
+              autocorrect="off"
+              autocapitalize="off"
+              spellcheck="false"
+              class="h-10 w-full rounded-md border border-input bg-background pl-8 pr-3 text-base outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-[hsl(var(--tac-amber)/0.6)] focus-visible:ring-1 focus-visible:ring-[hsl(var(--tac-amber)/0.4)] [&::-webkit-search-cancel-button]:appearance-none"
+              @input="
+                (e: Event) =>
+                  debouncedSearch((e.target as HTMLInputElement).value)
+              "
+              @keydown="onKeydown"
+            />
           </div>
+          <FilterRail>
+            <FilterChip
+              :active="onlineOnly"
+              :label="$t('common.online')"
+              @toggle="toggleOnlineOnly"
+            />
+            <FilterChip
+              v-if="canFilterRegistered"
+              :active="registeredOnlyFilter"
+              :label="$t('search.registered')"
+              @toggle="toggleRegisteredOnly"
+            />
+          </FilterRail>
         </div>
       </div>
     </DrawerContent>
@@ -201,28 +213,38 @@ const { height: viewportHeight } = useVisualViewport();
     </PopoverTrigger>
     <PopoverContent class="p-0 w-[400px]">
       <div class="flex flex-col">
-        <div class="flex items-center justify-between px-3 py-2 border-b">
-          <input
-            v-model="query"
-            :placeholder="$t('player.search.placeholder')"
-            type="search"
-            inputmode="search"
-            enterkeyhint="search"
-            class="flex-1 bg-transparent outline-none"
-            @input="
-              (e: Event) =>
-                debouncedSearch((e.target as HTMLInputElement).value)
-            "
-            @keydown="onKeydown"
-          />
-          <div class="flex items-center gap-2 ml-4">
-            <Switch
-              class="text-sm text-muted-foreground cursor-pointer flex items-center gap-2"
-              :model-value="onlineOnly"
-              @click="toggleOnlineOnly"
+        <div class="flex flex-col gap-2.5 p-3 border-b">
+          <div class="relative">
+            <Search
+              class="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
             />
-            {{ $t("common.online") }}
+            <input
+              v-model="query"
+              :placeholder="$t('player.search.placeholder')"
+              type="search"
+              inputmode="search"
+              enterkeyhint="search"
+              class="h-9 w-full rounded-md border border-input bg-background pl-8 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-[hsl(var(--tac-amber)/0.6)] focus-visible:ring-1 focus-visible:ring-[hsl(var(--tac-amber)/0.4)] [&::-webkit-search-cancel-button]:appearance-none"
+              @input="
+                (e: Event) =>
+                  debouncedSearch((e.target as HTMLInputElement).value)
+              "
+              @keydown="onKeydown"
+            />
           </div>
+          <FilterRail>
+            <FilterChip
+              :active="onlineOnly"
+              :label="$t('common.online')"
+              @toggle="toggleOnlineOnly"
+            />
+            <FilterChip
+              v-if="canFilterRegistered"
+              :active="registeredOnlyFilter"
+              :label="$t('search.registered')"
+              @toggle="toggleRegisteredOnly"
+            />
+          </FilterRail>
         </div>
 
         <div ref="scrollEl" class="max-h-[300px] overflow-y-auto">
@@ -489,6 +511,20 @@ export default {
         ...base.filter((p: Player) => String(p.steam_id) !== meId),
       ];
     },
+    // A context that requires registered players (lobbies, drafts) passes the
+    // prop and owns the filter outright, so there is nothing to offer.
+    canFilterRegistered(): boolean {
+      return !this.registeredOnly;
+    },
+    registeredOnlyFilter: {
+      get(): boolean {
+        return this.registeredOnly || useSearchStore().registeredOnly;
+      },
+      set(value: boolean) {
+        localStorage.setItem("playerSearchRegisteredOnly", value.toString());
+        useSearchStore().registeredOnly = value;
+      },
+    },
     onlineOnly: {
       get() {
         return useSearchStore().onlineOnly;
@@ -652,6 +688,13 @@ export default {
         (this.$refs.mobileSearchInput as HTMLInputElement)?.focus();
       });
     },
+    toggleRegisteredOnly() {
+      this.registeredOnlyFilter = !this.registeredOnlyFilter;
+      this.searchPlayers();
+      this.$nextTick(() => {
+        (this.$refs.mobileSearchInput as HTMLInputElement)?.focus();
+      });
+    },
     select(player: Player) {
       if (!player || this.isIneligible(player)) {
         return;
@@ -668,7 +711,7 @@ export default {
           query: this.query,
           teamId: this.teamId,
           exclude: this.hardExcluded,
-          registeredOnly: this.registeredOnly,
+          registeredOnly: this.registeredOnlyFilter,
           page,
           per_page: PAGE_SIZE,
         },

--- a/components/PlayerSearch.vue
+++ b/components/PlayerSearch.vue
@@ -561,6 +561,13 @@ export default {
           const id = String(f.steam_id);
           if (excluded.has(id)) return false;
           if (!this.canSelectSelf && id === meId) return false;
+          // The Registered chip has to hold here too. Only the Typesense path
+          // honoured it, so the Friends group kept listing Steam contacts who
+          // never signed in -- and picking one fails downstream, on a surface
+          // that said it was showing registered players only.
+          if (this.registeredOnlyFilter && f.player?.is_registered === false) {
+            return false;
+          }
           // Strictly respect the toggle: online-only -> only online friends,
           // otherwise -> only offline friends.
           const online = onlineIds.has(id);

--- a/components/SpotlightPlayerSearch.vue
+++ b/components/SpotlightPlayerSearch.vue
@@ -57,6 +57,10 @@ onUnmounted(() => {
 });
 
 const searchToken = ref(0);
+// Off by default: any Steam account stays findable. This narrows results to
+// people who have actually signed in here, for when you're looking for someone
+// you can invite rather than just look up.
+const registeredOnly = ref(false);
 
 const debouncedSearch = debounce(async (searchQuery: string) => {
   // A slower earlier keystroke must not clobber a newer result set.
@@ -75,6 +79,7 @@ const debouncedSearch = debounce(async (searchQuery: string) => {
       body: {
         query: searchQuery,
         per_page: 10,
+        registeredOnly: registeredOnly.value,
       },
     });
 
@@ -94,6 +99,9 @@ const debouncedSearch = debounce(async (searchQuery: string) => {
       is_banned: document.is_banned,
       is_muted: document.is_muted,
       is_gagged: document.is_gagged,
+      // Whether they have ever signed in here, as opposed to a Steam account we
+      // only know about. Every player stays searchable either way.
+      is_registered: document.is_registered,
       elo: {
         competitive: document.elo_competitive,
         wingman: document.elo_wingman,
@@ -116,6 +124,11 @@ const debouncedSearch = debounce(async (searchQuery: string) => {
 watch(query, (newQuery) => {
   selectedIndex.value = 0; // Reset selection when query changes
   debouncedSearch(newQuery);
+});
+
+watch(registeredOnly, () => {
+  selectedIndex.value = 0;
+  debouncedSearch(query.value);
 });
 
 const selectPlayer = (player: any) => {
@@ -195,6 +208,26 @@ const closeOnOverlayClick = (event: MouseEvent) => {
               class="flex-1 border-none bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 text-base px-0 h-auto"
               autofocus
             />
+
+            <button
+              type="button"
+              :aria-pressed="registeredOnly"
+              class="shrink-0 flex h-7 cursor-pointer items-center gap-2 rounded-full border px-3 font-mono text-[0.6rem] uppercase tracking-[0.12em] transition-colors duration-150"
+              :class="
+                registeredOnly
+                  ? 'border-[hsl(var(--tac-amber)/0.55)] bg-[hsl(var(--tac-amber)/0.13)] text-[hsl(var(--tac-amber))]'
+                  : 'border-border bg-muted/30 text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+              "
+              @click="registeredOnly = !registeredOnly"
+            >
+              <span
+                class="size-1.5 rounded-full transition-colors duration-150"
+                :class="
+                  registeredOnly ? 'bg-[hsl(var(--tac-amber))]' : 'bg-border'
+                "
+              />
+              {{ $t("search.registered_only") }}
+            </button>
           </div>
 
           <!-- Results -->
@@ -231,6 +264,15 @@ const closeOnOverlayClick = (event: MouseEvent) => {
                 @mouseenter="selectedIndex = index"
               >
                 <PlayerDisplay :player="player" />
+                <!-- A Steam account we know of but who has never signed in
+                     here. Still searchable -- this only sets expectations about
+                     what their profile will have on it. -->
+                <span
+                  v-if="player.is_registered === false"
+                  class="ml-auto shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-[0.6rem] uppercase tracking-[0.1em] text-muted-foreground"
+                >
+                  {{ $t("search.unregistered") }}
+                </span>
               </div>
             </div>
           </div>

--- a/components/SpotlightPlayerSearch.vue
+++ b/components/SpotlightPlayerSearch.vue
@@ -71,16 +71,11 @@ const registeredOnly = computed({
   },
 });
 
-// Same preference the other player searches use. On, results come from the
-// live online roster rather than Typesense, so registration is not a
-// distinction the store can make and that filter steps aside.
-const onlineOnly = computed({
-  get: () => searchStore.onlineOnly,
-  set: (value: boolean) => {
-    localStorage.setItem("playerSearchOnlineOnly", String(value));
-    searchStore.onlineOnly = value;
-  },
-});
+// Deliberately NOT the shared playerSearchOnlineOnly preference, which defaults
+// to on. This search exists to reach any player's profile, so defaulting it to
+// the online roster would make everyone who is not currently connected
+// unfindable from the keyboard shortcut. Session-local and off by default.
+const onlineOnly = ref(false);
 
 const debouncedSearch = debounce(async (searchQuery: string) => {
   // A slower earlier keystroke must not clobber a newer result set.

--- a/components/SpotlightPlayerSearch.vue
+++ b/components/SpotlightPlayerSearch.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { Input } from "~/components/ui/input";
+import FilterChip from "~/components/common/FilterChip.vue";
 import PlayerDisplay from "~/components/PlayerDisplay.vue";
 import debounce from "~/utilities/debounce";
 import { MagnifyingGlassIcon } from "@radix-icons/vue";
@@ -59,8 +60,27 @@ onUnmounted(() => {
 const searchToken = ref(0);
 // Off by default: any Steam account stays findable. This narrows results to
 // people who have actually signed in here, for when you're looking for someone
-// you can invite rather than just look up.
-const registeredOnly = ref(false);
+// you can invite rather than just look up. Shared with the other player
+// searches so the preference does not reset when you switch surfaces.
+const searchStore = useSearchStore();
+const registeredOnly = computed({
+  get: () => searchStore.registeredOnly,
+  set: (value: boolean) => {
+    localStorage.setItem("playerSearchRegisteredOnly", String(value));
+    searchStore.registeredOnly = value;
+  },
+});
+
+// Same preference the other player searches use. On, results come from the
+// live online roster rather than Typesense, so registration is not a
+// distinction the store can make and that filter steps aside.
+const onlineOnly = computed({
+  get: () => searchStore.onlineOnly,
+  set: (value: boolean) => {
+    localStorage.setItem("playerSearchOnlineOnly", String(value));
+    searchStore.onlineOnly = value;
+  },
+});
 
 const debouncedSearch = debounce(async (searchQuery: string) => {
   // A slower earlier keystroke must not clobber a newer result set.
@@ -68,6 +88,14 @@ const debouncedSearch = debounce(async (searchQuery: string) => {
 
   if (!searchQuery.trim()) {
     players.value = [];
+    return;
+  }
+
+  // The online roster is already in memory, so this path needs no request and
+  // no loading state.
+  if (onlineOnly.value) {
+    players.value = searchStore.search(searchQuery, []);
+    loading.value = false;
     return;
   }
 
@@ -126,7 +154,7 @@ watch(query, (newQuery) => {
   debouncedSearch(newQuery);
 });
 
-watch(registeredOnly, () => {
+watch([registeredOnly, onlineOnly], () => {
   selectedIndex.value = 0;
   debouncedSearch(query.value);
 });
@@ -209,25 +237,17 @@ const closeOnOverlayClick = (event: MouseEvent) => {
               autofocus
             />
 
-            <button
-              type="button"
-              :aria-pressed="registeredOnly"
-              class="shrink-0 flex h-7 cursor-pointer items-center gap-2 rounded-full border px-3 font-mono text-[0.6rem] uppercase tracking-[0.12em] transition-colors duration-150"
-              :class="
-                registeredOnly
-                  ? 'border-[hsl(var(--tac-amber)/0.55)] bg-[hsl(var(--tac-amber)/0.13)] text-[hsl(var(--tac-amber))]'
-                  : 'border-border bg-muted/30 text-muted-foreground hover:bg-muted/50 hover:text-foreground'
-              "
-              @click="registeredOnly = !registeredOnly"
-            >
-              <span
-                class="size-1.5 rounded-full transition-colors duration-150"
-                :class="
-                  registeredOnly ? 'bg-[hsl(var(--tac-amber))]' : 'bg-border'
-                "
-              />
-              {{ $t("search.registered_only") }}
-            </button>
+            <FilterChip
+              :active="onlineOnly"
+              :label="$t('common.online')"
+              @toggle="onlineOnly = !onlineOnly"
+            />
+
+            <FilterChip
+              :active="registeredOnly"
+              :label="$t('search.registered')"
+              @toggle="registeredOnly = !registeredOnly"
+            />
           </div>
 
           <!-- Results -->

--- a/components/TimeAgo.vue
+++ b/components/TimeAgo.vue
@@ -92,6 +92,13 @@ export default {
       type: Boolean,
       default: false,
     },
+    // Counts down to a future date instead of up from a past one. `seconds`
+    // alone renders now - date, which goes negative for anything upcoming.
+    countdown: {
+      required: false,
+      type: Boolean,
+      default: false,
+    },
     hideIcon: {
       required: false,
       type: Boolean,
@@ -129,7 +136,10 @@ export default {
   methods: {
     attach() {
       if (this.unsubscribe) return;
-      this.unsubscribe = subscribe(this.seconds, () => this.updateText());
+      this.unsubscribe = subscribe(
+        this.seconds || this.countdown,
+        () => this.updateText(),
+      );
     },
     detach() {
       this.unsubscribe?.();
@@ -142,6 +152,24 @@ export default {
         this.text = "";
         return;
       }
+      if (this.countdown) {
+        const remaining = Math.max(
+          0,
+          Math.floor((time.getTime() - Date.now()) / 1000),
+        );
+        const hours = Math.floor(remaining / 3600);
+        const minutes = Math.floor((remaining % 3600) / 60);
+        const seconds = remaining % 60;
+
+        this.text =
+          hours > 0
+            ? `${hours}:${minutes.toString().padStart(2, "0")}:${seconds
+                .toString()
+                .padStart(2, "0")}`
+            : `${minutes}:${seconds.toString().padStart(2, "0")}`;
+        return;
+      }
+
       time.setSeconds(time.getSeconds() - 1);
 
       if (this.seconds) {

--- a/components/TimeAgo.vue
+++ b/components/TimeAgo.vue
@@ -136,9 +136,8 @@ export default {
   methods: {
     attach() {
       if (this.unsubscribe) return;
-      this.unsubscribe = subscribe(
-        this.seconds || this.countdown,
-        () => this.updateText(),
+      this.unsubscribe = subscribe(this.seconds || this.countdown, () =>
+        this.updateText(),
       );
     },
     detach() {
@@ -182,18 +181,16 @@ export default {
         const minutes = Math.floor((diffInSeconds % 3600) / 60);
         const seconds = diffInSeconds % 60;
 
-        let timeText = "";
-        if (hours > 0) {
-          timeText += `${hours}:`;
-        }
-        if (minutes > 0) {
-          timeText += `${minutes}:`;
-        }
-        if (seconds > 0 || timeText === "") {
-          timeText += `${seconds.toString().padStart(2, "0")}`;
-        }
+        // Every segment below the largest one is always emitted, zero padded.
+        // Dropping empty segments rendered exactly three minutes as "3:", and
+        // collapsed 1h00m30s to "1:30" -- which reads as a minute and a half,
+        // so the timer appeared to run backwards from "59:59".
+        const pad = (value: number) => value.toString().padStart(2, "0");
 
-        this.text = timeText.trim();
+        this.text =
+          hours > 0
+            ? `${hours}:${pad(minutes)}:${pad(seconds)}`
+            : `${minutes}:${pad(seconds)}`;
       } else {
         this.text = timeAgo.format(time);
       }

--- a/components/chat/ChatLobby.vue
+++ b/components/chat/ChatLobby.vue
@@ -331,6 +331,9 @@ export default {
       validator: (value: string) =>
         [
           "match",
+          // One side of a match, keyed `${matchId}:${lineupId}`. Distinct from
+          // "team", which is a real team's permanent room.
+          "match_team",
           "team",
           "matchmaking",
           "organizers",

--- a/components/chat/ChatLobby.vue
+++ b/components/chat/ChatLobby.vue
@@ -164,10 +164,7 @@ import Empty from "~/components/ui/empty/Empty.vue";
           variant="global"
           @send-message="handleSendMessage"
         />
-        <div
-          v-else
-          class="px-3 py-2 text-center text-xs text-muted-foreground"
-        >
+        <div v-else class="px-3 py-2 text-center text-xs text-muted-foreground">
           {{ readonlyHint || $t("chat.readonly") }}
         </div>
       </div>
@@ -183,6 +180,20 @@ import Empty from "~/components/ui/empty/Empty.vue";
       class="mb-2 flex items-center justify-between text-[11px] text-muted-foreground gap-3"
     >
       <div class="flex items-center gap-1.5">
+        <!-- Two chat panels can sit stacked on the same page (the whole match
+             room and a single lineup's room) and are otherwise identical, so
+             the one you are typing into has to say which it is. -->
+        <span
+          v-if="label"
+          class="inline-flex items-center rounded-sm border px-1.5 py-[1px] font-mono text-[0.55rem] font-bold uppercase leading-none tracking-[0.14em]"
+          :class="
+            isTeamContext
+              ? 'border-[hsl(var(--tac-amber)/0.5)] bg-[hsl(var(--tac-amber)/0.12)] text-[hsl(var(--tac-amber))]'
+              : 'border-border bg-muted/40 text-muted-foreground'
+          "
+        >
+          {{ label }}
+        </span>
         <span
           class="inline-flex h-2.5 w-2.5 rounded-full"
           :class="participantsCount > 0 ? 'bg-emerald-400' : 'bg-zinc-500/60'"
@@ -287,10 +298,7 @@ import Empty from "~/components/ui/empty/Empty.vue";
         variant="embedded"
         @send-message="handleSendMessage"
       />
-      <div
-        v-else
-        class="px-3 py-2 text-center text-xs text-muted-foreground"
-      >
+      <div v-else class="px-3 py-2 text-center text-xs text-muted-foreground">
         {{ readonlyHint || $t("chat.readonly") }}
       </div>
     </div>
@@ -324,6 +332,13 @@ export default {
     lobbyId: {
       type: String,
       required: true,
+    },
+    // Shown as a badge above the messages. Only needed where more than one
+    // lobby is on screen at once.
+    label: {
+      type: String,
+      required: false,
+      default: "",
     },
     type: {
       type: String,
@@ -401,6 +416,10 @@ export default {
     };
   },
   computed: {
+    // Only a single lineup's room is private; the match room admits both sides.
+    isTeamContext() {
+      return this.type === "match_team" || this.type === "team";
+    },
     rightSidebarOffset() {
       const baseOffset = 96;
 

--- a/components/common/FilterChip.vue
+++ b/components/common/FilterChip.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+defineProps<{
+  active: boolean;
+  label: string;
+}>();
+
+defineEmits<{
+  (e: "toggle"): void;
+}>();
+</script>
+
+<template>
+  <button
+    type="button"
+    :aria-pressed="active"
+    class="inline-flex h-6 shrink-0 cursor-pointer items-center gap-1.5 rounded-sm border px-2 font-mono text-[0.6rem] font-bold uppercase leading-none tracking-[0.14em] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[hsl(var(--tac-amber)/0.6)]"
+    :class="
+      active
+        ? 'border-[hsl(var(--tac-amber)/0.5)] bg-[hsl(var(--tac-amber)/0.1)] text-[hsl(var(--tac-amber))]'
+        : 'border-border/70 bg-transparent text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground'
+    "
+    @click="$emit('toggle')"
+  >
+    <!-- Same tick as the section labels below the rail, so an active filter
+         reads as belonging to the list it is filtering. -->
+    <span
+      class="h-[2px] w-2 shrink-0 transition-colors duration-150"
+      :class="active ? 'bg-[hsl(var(--tac-amber))]' : 'bg-border'"
+    />
+    {{ label }}
+  </button>
+</template>

--- a/components/common/FilterRail.vue
+++ b/components/common/FilterRail.vue
@@ -1,0 +1,8 @@
+<template>
+  <!-- Chips plus a hairline that runs out to the edge, so a rail holding a
+       single filter still reads as a bar rather than a stray pill. -->
+  <div class="flex items-center gap-1.5">
+    <slot />
+    <span class="h-px min-w-4 flex-1 bg-border/50" />
+  </div>
+</template>

--- a/components/common/FilterToggle.vue
+++ b/components/common/FilterToggle.vue
@@ -32,7 +32,7 @@ const TONES = {
   },
   warning: {
     label: "text-yellow-500",
-    track: "border-yellow-500/55 bg-yellow-500/18",
+    track: "border-yellow-500/55 bg-yellow-500/20",
     knob: "bg-yellow-500 shadow-[0_0_6px_theme(colors.yellow.500/0.55)]",
   },
 } as const;

--- a/components/common/FilterToggle.vue
+++ b/components/common/FilterToggle.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean;
+    label: string;
+    // Sanction flags carry their own meaning -- a banned filter reading amber
+    // like every other filter loses that. The control stays identical; only
+    // the lit colour changes.
+    tone?: "amber" | "danger" | "warning";
+  }>(),
+  { tone: "amber" },
+);
+
+defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+}>();
+
+const TONES = {
+  amber: {
+    label: "text-[hsl(var(--tac-amber))]",
+    track:
+      "border-[hsl(var(--tac-amber)/0.55)] bg-[hsl(var(--tac-amber)/0.18)]",
+    knob: "bg-[hsl(var(--tac-amber))] shadow-[0_0_6px_hsl(var(--tac-amber)/0.55)]",
+  },
+  danger: {
+    label: "text-destructive",
+    track:
+      "border-[hsl(var(--destructive)/0.55)] bg-[hsl(var(--destructive)/0.18)]",
+    knob: "bg-destructive shadow-[0_0_6px_hsl(var(--destructive)/0.55)]",
+  },
+  warning: {
+    label: "text-yellow-500",
+    track: "border-yellow-500/55 bg-yellow-500/18",
+    knob: "bg-yellow-500 shadow-[0_0_6px_theme(colors.yellow.500/0.55)]",
+  },
+} as const;
+
+const tone = computed(() => TONES[props.tone]);
+</script>
+
+<template>
+  <button
+    type="button"
+    role="switch"
+    :aria-checked="modelValue"
+    class="group flex w-full items-center justify-between gap-3 rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[hsl(var(--tac-amber)/0.5)]"
+    :class="modelValue ? tone.label : 'text-foreground/90'"
+    @click="$emit('update:modelValue', !modelValue)"
+  >
+    <span class="flex min-w-0 items-center gap-2 text-left">
+      <slot name="icon" />
+      <span class="truncate">{{ label }}</span>
+    </span>
+
+    <!-- Squared off rather than the pill switch: these panels are dense, sharp
+         cornered and mono set, and a rocker reads as instrumentation in a way a
+         rounded pill does not. Both states are visible at rest, which the bare
+         check mark this replaces could not do. -->
+    <span
+      class="flex h-4 w-7 shrink-0 items-center rounded-[3px] border px-[2px] transition-colors duration-150"
+      :class="
+        modelValue
+          ? tone.track
+          : 'border-border bg-muted/40 group-hover:border-muted-foreground/40'
+      "
+    >
+      <span
+        class="size-2.5 rounded-[2px] transition-all duration-150 ease-out"
+        :class="
+          modelValue
+            ? `translate-x-3 ${tone.knob}`
+            : 'translate-x-0 bg-muted-foreground/40 group-hover:bg-muted-foreground/60'
+        "
+      />
+    </span>
+  </button>
+</template>

--- a/components/league/RegistrationReviewTable.vue
+++ b/components/league/RegistrationReviewTable.vue
@@ -93,6 +93,8 @@ function teamRanks(row: TeamSeasonRow) {
     players.map(fn).filter((v): v is number => v != null);
   return {
     avg_elo: avg(nums((p) => p.elo?.competitive)),
+    avg_wingman_elo: avg(nums((p) => p.elo?.wingman)),
+    avg_duel_elo: avg(nums((p) => p.elo?.duel)),
     avg_premier: avg(nums((p) => p.premier_rank)),
     avg_faceit_elo: avg(nums((p) => p.faceit_elo)),
     avg_faceit_level: avg(nums((p) => p.faceit_skill_level)),

--- a/components/match/MatchMaps.vue
+++ b/components/match/MatchMaps.vue
@@ -80,6 +80,12 @@ import mapLabel from "~/utilities/mapLabel";
           class="text-xs px-2 py-0.5 backdrop-blur-sm"
           >{{ matchMap.status.replace(/([a-z])([A-Z])/g, "$1 $2") }}</Badge
         >
+        <Badge
+          v-else-if="isDecider && match.options.best_of > 1"
+          variant="destructive"
+          class="text-xs px-2 py-0.5 backdrop-blur-sm"
+          >{{ $t("match.decider") }}</Badge
+        >
         <!-- Sits on the map it belongs to: the status badge already says the
              demo is being processed, this says for how long. -->
         <Tooltip v-if="demoProcessingStartedAt">
@@ -98,12 +104,6 @@ import mapLabel from "~/utilities/mapLabel";
             </p>
           </TooltipContent>
         </Tooltip>
-        <Badge
-          v-else-if="isDecider && match.options.best_of > 1"
-          variant="destructive"
-          class="text-xs px-2 py-0.5 backdrop-blur-sm"
-          >{{ $t("match.decider") }}</Badge
-        >
         <template v-if="hasDemo && hasDemoMetadata">
           <Tooltip v-if="mapHasRadar">
             <TooltipTrigger as-child>

--- a/components/match/MatchMaps.vue
+++ b/components/match/MatchMaps.vue
@@ -11,6 +11,7 @@ import {
   MoreVertical,
 } from "lucide-vue-next";
 import { Spinner } from "~/components/ui/spinner";
+import TimeAgo from "~/components/TimeAgo.vue";
 import MatchSelectMapWinner from "~/components/match/MatchSelectMapWinner.vue";
 import { toast } from "@/components/ui/toast";
 import { generateMutation } from "~/graphql/graphqlGen";
@@ -79,6 +80,24 @@ import mapLabel from "~/utilities/mapLabel";
           class="text-xs px-2 py-0.5 backdrop-blur-sm"
           >{{ matchMap.status.replace(/([a-z])([A-Z])/g, "$1 $2") }}</Badge
         >
+        <!-- Sits on the map it belongs to: the status badge already says the
+             demo is being processed, this says for how long. -->
+        <Tooltip v-if="demoProcessingStartedAt">
+          <TooltipTrigger as-child>
+            <span
+              class="inline-flex h-[1.35rem] items-center gap-1 rounded-sm border border-[hsl(var(--tac-amber)/0.45)] bg-[hsl(var(--tac-amber)/0.12)] px-1.5 font-mono text-[0.6rem] font-bold leading-none tracking-[0.1em] text-[hsl(var(--tac-amber))] backdrop-blur-sm [font-variant-numeric:tabular-nums]"
+            >
+              <Spinner class="h-2.5 w-2.5 shrink-0" />
+              <TimeAgo :date="demoProcessingStartedAt" seconds hide-icon />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent class="max-w-[15rem]">
+            <p class="font-semibold">{{ $t("match.demo_processing") }}</p>
+            <p class="mt-1 text-muted-foreground">
+              {{ $t("match.demo_processing_hint") }}
+            </p>
+          </TooltipContent>
+        </Tooltip>
         <Badge
           v-else-if="isDecider && match.options.best_of > 1"
           variant="destructive"
@@ -374,6 +393,19 @@ export default {
     });
   },
   computed: {
+    // Anchored on the server's own timestamp, so a refresh keeps counting from
+    // when processing actually began rather than restarting at page load.
+    // Deliberately elapsed time, not a countdown: how long demo upload takes
+    // depends on tv_delay and transfer speed, so any predicted finish would be
+    // a guess that goes stale the moment it is wrong.
+    demoProcessingStartedAt() {
+      if (
+        !["WaitingForTV", "UploadingDemo"].includes(this.matchMap.status ?? "")
+      ) {
+        return null;
+      }
+      return this.matchMap.demo_processing_started_at ?? null;
+    },
     canOpenStats() {
       if (this.matchMap.status === e_match_status_enum.Scheduled) {
         return false;

--- a/components/match/MatchSelectWinner.vue
+++ b/components/match/MatchSelectWinner.vue
@@ -81,23 +81,43 @@ export default {
   },
   methods: {
     async updateMatchWinner() {
-      await this.$apollo.mutate({
-        mutation: generateMutation({
-          update_matches_by_pk: [
-            {
-              pk_columns: {
-                id: this.match.id,
-              },
-              _set: {
+      // setMatchWinner takes a non-null lineup. The select only ever offers
+      // the two lineups, so this is just a guard against firing before one
+      // has been chosen.
+      if (!this.form.values.lineup_id) {
+        return;
+      }
+
+      // Goes through setMatchWinner rather than writing winning_lineup_id
+      // directly: the action is what enforces organizer permission and blocks
+      // a reassignment once a downstream tournament match has already been
+      // played. A direct mutation skips both.
+      try {
+        await this.$apollo.mutate({
+          mutation: generateMutation({
+            setMatchWinner: [
+              {
+                match_id: this.match.id,
                 winning_lineup_id: this.form.values.lineup_id,
               },
-            },
-            {
-              id: true,
-            },
-          ],
-        }),
-      });
+              {
+                success: true,
+              },
+            ],
+          }),
+        });
+      } catch (error) {
+        // Put the selector back on the winner the match actually has, so it
+        // doesn't sit showing a change that was rejected.
+        this.form.setFieldValue("lineup_id", this.match.winning_lineup_id);
+
+        toast({
+          title: this.$t("match.winner.set_failed"),
+          description: (error as Error)?.message,
+          variant: "destructive",
+        });
+        return;
+      }
 
       toast({
         title: this.$t("match.winner.set"),

--- a/components/matchmaking-lobby/PlayersList.vue
+++ b/components/matchmaking-lobby/PlayersList.vue
@@ -43,6 +43,27 @@ import FriendListItem from "~/components/matchmaking-lobby/FriendListItem.vue";
       </Tooltip>
     </div>
 
+    <!-- Steam friends who have never signed in here are still added, so this
+         hides them without changing who gets synced. -->
+    <button
+      v-if="friendsOnly"
+      type="button"
+      :aria-pressed="registeredFriendsOnly"
+      class="self-start flex h-7 cursor-pointer items-center gap-2 rounded-full border px-3 font-mono text-[0.6rem] uppercase tracking-[0.12em] transition-colors duration-150"
+      :class="
+        registeredFriendsOnly
+          ? 'border-[hsl(var(--tac-amber)/0.55)] bg-[hsl(var(--tac-amber)/0.13)] text-[hsl(var(--tac-amber))]'
+          : 'border-border bg-muted/30 text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+      "
+      @click="registeredFriendsOnly = !registeredFriendsOnly"
+    >
+      <span
+        class="size-1.5 rounded-full transition-colors duration-150"
+        :class="registeredFriendsOnly ? 'bg-[hsl(var(--tac-amber))]' : 'bg-border'"
+      />
+      {{ $t("search.registered_only") }}
+    </button>
+
     <div class="flex flex-col gap-4">
       <!-- Incoming friend requests (friends tab) -->
       <section v-if="friendsOnly && incomingRequests.length > 0">
@@ -166,6 +187,16 @@ export default {
     },
     onlinePlayers() {
       return useMatchmakingStore().playersOnline;
+    },
+    // Writable so the toggle drives the store's own ref, keeping both the
+    // online and offline lists in step.
+    registeredFriendsOnly: {
+      get(): boolean {
+        return useMatchmakingStore().registeredFriendsOnly;
+      },
+      set(value: boolean) {
+        useMatchmakingStore().registeredFriendsOnly = value;
+      },
     },
     onlineFriends() {
       return useMatchmakingStore().onlineFriends;

--- a/components/matchmaking-lobby/PlayersList.vue
+++ b/components/matchmaking-lobby/PlayersList.vue
@@ -231,8 +231,12 @@ export default {
     },
     filteredOnlinePlayers() {
       if (this.friendsOnly) {
-        return this.onlineFriends.filter((p: any) =>
-          matchesSearch(p, this.searchQuery),
+        // Applied here rather than in the store: the shared friend lists also
+        // feed the hub badge and social panel, which have no such toggle.
+        return this.onlineFriends.filter(
+          (p: any) =>
+            matchesSearch(p, this.searchQuery) &&
+            this.passesRegisteredFilter(p),
         );
       }
 
@@ -257,8 +261,9 @@ export default {
     },
     filteredOfflinePlayers() {
       if (!this.friendsOnly) return [];
-      return this.offlineFriends.filter((p: any) =>
-        matchesSearch(p, this.searchQuery),
+      return this.offlineFriends.filter(
+        (p: any) =>
+          matchesSearch(p, this.searchQuery) && this.passesRegisteredFilter(p),
       );
     },
     isEmpty(): boolean {
@@ -279,6 +284,12 @@ export default {
     },
   },
   methods: {
+    passesRegisteredFilter(player: any) {
+      if (!this.registeredFriendsOnly) {
+        return true;
+      }
+      return useMatchmakingStore().isRegisteredFriend(player);
+    },
     async syncSteamFriends() {
       this.syncing = true;
       try {

--- a/components/matchmaking-lobby/PlayersList.vue
+++ b/components/matchmaking-lobby/PlayersList.vue
@@ -6,7 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
-import { Search, RefreshCw } from "lucide-vue-next";
+import { Search, RefreshCw, UserCheck } from "lucide-vue-next";
 import FriendListItem from "~/components/matchmaking-lobby/FriendListItem.vue";
 </script>
 
@@ -21,48 +21,53 @@ import FriendListItem from "~/components/matchmaking-lobby/FriendListItem.vue";
           class="pl-8"
         />
       </div>
-      <Tooltip v-if="friendsOnly">
-        <TooltipTrigger as-child>
-          <Button
-            variant="ghost"
-            size="icon"
-            class="h-9 w-9 transition-opacity"
-            :class="{ 'opacity-50': syncing }"
-            @click="syncSteamFriends"
-          >
-            <RefreshCw
-              class="h-4 w-4 transition-transform"
-              :class="{ 'animate-spin-smooth': syncing }"
-            />
-            <span class="sr-only">{{ $t("matchmaking.friends.sync") }}</span>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          {{ $t("matchmaking.friends.sync") }}
-        </TooltipContent>
-      </Tooltip>
+      <div v-if="friendsOnly" class="flex shrink-0 items-center gap-0.5">
+        <!-- Steam friends who have never signed in here are still added, so
+             this hides them without changing who gets synced. -->
+        <Tooltip>
+          <TooltipTrigger as-child>
+            <Button
+              variant="ghost"
+              size="icon"
+              :aria-pressed="registeredFriendsOnly"
+              class="size-9 shrink-0 transition-colors"
+              :class="
+                registeredFriendsOnly
+                  ? 'bg-[hsl(var(--tac-amber)/0.12)] text-[hsl(var(--tac-amber))] hover:bg-[hsl(var(--tac-amber)/0.18)] hover:text-[hsl(var(--tac-amber))]'
+                  : 'text-muted-foreground'
+              "
+              @click="registeredFriendsOnly = !registeredFriendsOnly"
+            >
+              <UserCheck class="size-4" />
+              <span class="sr-only">{{ $t("search.registered_only") }}</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {{ $t("search.registered_only") }}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger as-child>
+            <Button
+              variant="ghost"
+              size="icon"
+              class="size-9 shrink-0 text-muted-foreground transition-opacity"
+              :class="{ 'opacity-50': syncing }"
+              @click="syncSteamFriends"
+            >
+              <RefreshCw
+                class="size-4 transition-transform"
+                :class="{ 'animate-spin-smooth': syncing }"
+              />
+              <span class="sr-only">{{ $t("matchmaking.friends.sync") }}</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {{ $t("matchmaking.friends.sync") }}
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </div>
-
-    <!-- Steam friends who have never signed in here are still added, so this
-         hides them without changing who gets synced. -->
-    <button
-      v-if="friendsOnly"
-      type="button"
-      :aria-pressed="registeredFriendsOnly"
-      class="self-start flex h-7 cursor-pointer items-center gap-2 rounded-full border px-3 font-mono text-[0.6rem] uppercase tracking-[0.12em] transition-colors duration-150"
-      :class="
-        registeredFriendsOnly
-          ? 'border-[hsl(var(--tac-amber)/0.55)] bg-[hsl(var(--tac-amber)/0.13)] text-[hsl(var(--tac-amber))]'
-          : 'border-border bg-muted/30 text-muted-foreground hover:bg-muted/50 hover:text-foreground'
-      "
-      @click="registeredFriendsOnly = !registeredFriendsOnly"
-    >
-      <span
-        class="size-1.5 rounded-full transition-colors duration-150"
-        :class="registeredFriendsOnly ? 'bg-[hsl(var(--tac-amber))]' : 'bg-border'"
-      />
-      {{ $t("search.registered_only") }}
-    </button>
 
     <div class="flex flex-col gap-4">
       <!-- Incoming friend requests (friends tab) -->
@@ -90,7 +95,9 @@ import FriendListItem from "~/components/matchmaking-lobby/FriendListItem.vue";
             <span
               class="absolute inline-flex h-full w-full rounded-full bg-green-500/60 animate-ping"
             />
-            <span class="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+            <span
+              class="relative inline-flex h-2 w-2 rounded-full bg-green-500"
+            />
           </span>
           {{ $t("common.online") }}
           <span class="ml-auto tabular-nums opacity-70">

--- a/components/matchmaking/Matchmaking.vue
+++ b/components/matchmaking/Matchmaking.vue
@@ -7,6 +7,24 @@ import TimeAgo from "../TimeAgo.vue";
 
 const isMobile = useMediaQuery("(max-width: 768px)");
 
+// Both the ban expiry and the matchmaking cooldown are timestamps. Rendered in
+// the viewer's own locale and timezone -- a raw ISO string is unreadable, and
+// the cooldown was previously passed to the message but never shown at all.
+// Takes unknown because the generated timestamptz scalar is untyped, so the
+// value arrives as {} rather than a string.
+const formatBanExpiry = (value: unknown) => {
+  const date = value instanceof Date ? value : new Date(String(value));
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
 const mmCardBase =
   "group/mmc relative flex flex-col flex-1 min-h-[120px] px-[1.1rem] pt-4 pb-5 text-left cursor-pointer overflow-hidden isolate border border-border text-foreground [background:linear-gradient(135deg,hsl(var(--card)/0.7)_0%,hsl(var(--card)/0.35)_60%,hsl(var(--tac-amber)/0.05)_100%)] [transition:border-color_180ms_ease,background_220ms_ease,box-shadow_220ms_ease] hover:border-[hsl(var(--tac-amber)/0.55)] hover:[background:linear-gradient(135deg,hsl(var(--card)/0.8)_0%,hsl(var(--card)/0.45)_55%,hsl(var(--tac-amber)/0.12)_100%)] hover:shadow-[0_0_24px_hsl(var(--tac-amber)/0.12)] focus-visible:outline-none focus-visible:border-[hsl(var(--tac-amber))] focus-visible:shadow-[0_0_0_2px_hsl(var(--tac-amber)/0.35)]";
 
@@ -50,7 +68,15 @@ function releaseSwapHeight(el: Element): void {
       <Alert class="my-3">
         <AlertDescription class="flex items-center gap-2">
           <AlertTriangle class="h-4 w-4" />
-          {{ $t("matchmaking.banned") }}
+          <!-- No date means the ban is permanent, so there is nothing to
+               count towards -- fall back to the plain message. -->
+          {{
+            me.banned_until
+              ? $t("matchmaking.banned_until", {
+                  time: formatBanExpiry(me.banned_until),
+                })
+              : $t("matchmaking.banned")
+          }}
         </AlertDescription>
       </Alert>
     </template>
@@ -60,7 +86,7 @@ function releaseSwapHeight(el: Element): void {
           <AlertTriangle class="h-4 w-4" />
           {{
             $t("matchmaking.temp_banned", {
-              time: me.matchmaking_cooldown,
+              time: formatBanExpiry(me.matchmaking_cooldown),
             })
           }}
         </AlertDescription>

--- a/components/matchmaking/Matchmaking.vue
+++ b/components/matchmaking/Matchmaking.vue
@@ -84,10 +84,15 @@ function releaseSwapHeight(el: Element): void {
       <Alert class="my-3">
         <AlertDescription class="flex items-center gap-2">
           <AlertTriangle class="h-4 w-4" />
+          <!-- Separate key rather than a placeholder bolted onto temp_banned:
+               every other locale already has that key without a {time} token,
+               so reusing it drops the expiry for all of them. -->
           {{
-            $t("matchmaking.temp_banned", {
-              time: formatBanExpiry(me.matchmaking_cooldown),
-            })
+            formatBanExpiry(me.matchmaking_cooldown)
+              ? $t("matchmaking.temp_banned_until", {
+                  time: formatBanExpiry(me.matchmaking_cooldown),
+                })
+              : $t("matchmaking.temp_banned")
           }}
         </AlertDescription>
       </Alert>

--- a/components/notification/NotificationContext.vue
+++ b/components/notification/NotificationContext.vue
@@ -8,7 +8,10 @@ import TeamRankSummary from "~/components/team/TeamRankSummary.vue";
 import { $ } from "~/generated/zeus";
 import { typedGql } from "~/generated/zeus/typedDocumentNode";
 
-const MATCH_TYPES = ["MatchStatusChange", "MatchSupport"];
+// MatchAbandoned carries the abandoned match's id, so it gets the same match
+// preview -- an admin seeing the alert can tell which match it was without
+// following the link.
+const MATCH_TYPES = ["MatchStatusChange", "MatchSupport", "MatchAbandoned"];
 const SERVER_TYPES = ["DedicatedServerStatus", "DedicatedServerRconStatus"];
 const NODE_TYPES = ["GameNodeStatus"];
 const PLAYER_TYPES = ["PlayerSanctioned"];
@@ -313,6 +316,8 @@ export default defineComponent({
               avatar_url: true,
               ranks: {
                 avg_elo: true,
+                avg_wingman_elo: true,
+                avg_duel_elo: true,
                 avg_faceit_level: true,
                 avg_faceit_elo: true,
                 avg_premier: true,
@@ -330,6 +335,8 @@ export default defineComponent({
               avatar_url: true,
               ranks: {
                 avg_elo: true,
+                avg_wingman_elo: true,
+                avg_duel_elo: true,
                 avg_faceit_level: true,
                 avg_faceit_elo: true,
                 avg_premier: true,

--- a/components/team/TeamRankSummary.vue
+++ b/components/team/TeamRankSummary.vue
@@ -6,6 +6,8 @@ import PlayerRanks from "~/components/draft-games/PlayerRanks.vue";
 const props = defineProps<{
   ranks?: {
     avg_elo?: number | null;
+    avg_wingman_elo?: number | null;
+    avg_duel_elo?: number | null;
     min_elo?: number | null;
     max_elo?: number | null;
     avg_faceit_level?: number | null;
@@ -23,7 +25,11 @@ const props = defineProps<{
 const hasRanks = computed(() => (props.ranks?.roster_size ?? 0) > 0);
 
 const player = computed(() => ({
-  elo: { competitive: props.ranks?.avg_elo ?? undefined },
+  elo: {
+    competitive: props.ranks?.avg_elo ?? undefined,
+    wingman: props.ranks?.avg_wingman_elo ?? undefined,
+    duel: props.ranks?.avg_duel_elo ?? undefined,
+  },
   premier_rank: props.ranks?.avg_premier ?? undefined,
   // FACEIT levels are 1–10 integers; round the team average so the badge shows
   // a whole level instead of an awkward decimal in the circular icon.

--- a/components/teams/TeamSearch.vue
+++ b/components/teams/TeamSearch.vue
@@ -641,6 +641,12 @@ export default {
             {
               id: true,
               avatar_url: true,
+              // The canonical team rating: season-aware and excluding coaches.
+              // Averaging the roster here instead silently disagrees with the
+              // team page, which reads this same view.
+              ranks: {
+                avg_elo: true,
+              },
               roster: [
                 { where: { status: { _in: ["Starter", "Substitute"] } } },
                 {
@@ -666,7 +672,9 @@ export default {
           ...team,
           avatar_url: team.avatar_url ?? details.avatar_url ?? null,
           player_count: roster.length,
-          avg_elo: teamAvgElo(roster),
+          // Falls back to the roster average only when the view has no row yet,
+          // so a card never renders blank.
+          avg_elo: details.ranks?.avg_elo ?? teamAvgElo(roster),
           avg_premier: teamAvgPremier(roster),
         };
       };

--- a/generated/zeus/const.ts
+++ b/generated/zeus/const.ts
@@ -126,6 +126,8 @@ export const AllTypesProps: Record<string,any> = {
 		_or:"abandoned_matches_bool_exp",
 		abandoned_at:"timestamptz_comparison_exp",
 		id:"uuid_comparison_exp",
+		match:"matches_bool_exp",
+		match_id:"uuid_comparison_exp",
 		steam_id:"bigint_comparison_exp"
 	},
 	abandoned_matches_constraint: "enum" as const,
@@ -135,16 +137,20 @@ export const AllTypesProps: Record<string,any> = {
 	abandoned_matches_insert_input:{
 		abandoned_at:"timestamptz",
 		id:"uuid",
+		match:"matches_obj_rel_insert_input",
+		match_id:"uuid",
 		steam_id:"bigint"
 	},
 	abandoned_matches_max_order_by:{
 		abandoned_at:"order_by",
 		id:"order_by",
+		match_id:"order_by",
 		steam_id:"order_by"
 	},
 	abandoned_matches_min_order_by:{
 		abandoned_at:"order_by",
 		id:"order_by",
+		match_id:"order_by",
 		steam_id:"order_by"
 	},
 	abandoned_matches_on_conflict:{
@@ -155,6 +161,8 @@ export const AllTypesProps: Record<string,any> = {
 	abandoned_matches_order_by:{
 		abandoned_at:"order_by",
 		id:"order_by",
+		match:"matches_order_by",
+		match_id:"order_by",
 		steam_id:"order_by"
 	},
 	abandoned_matches_pk_columns_input:{
@@ -164,6 +172,7 @@ export const AllTypesProps: Record<string,any> = {
 	abandoned_matches_set_input:{
 		abandoned_at:"timestamptz",
 		id:"uuid",
+		match_id:"uuid",
 		steam_id:"bigint"
 	},
 	abandoned_matches_stddev_order_by:{
@@ -182,6 +191,7 @@ export const AllTypesProps: Record<string,any> = {
 	abandoned_matches_stream_cursor_value_input:{
 		abandoned_at:"timestamptz",
 		id:"uuid",
+		match_id:"uuid",
 		steam_id:"bigint"
 	},
 	abandoned_matches_sum_order_by:{
@@ -6223,6 +6233,7 @@ export const AllTypesProps: Record<string,any> = {
 		matches_played:"Int_comparison_exp",
 		player_avatar_url:"String_comparison_exp",
 		player_country:"String_comparison_exp",
+		player_custom_avatar_url:"String_comparison_exp",
 		player_name:"String_comparison_exp",
 		player_steam_id:"String_comparison_exp",
 		secondary_value:"float8_comparison_exp",
@@ -6243,6 +6254,7 @@ export const AllTypesProps: Record<string,any> = {
 		matches_played:"order_by",
 		player_avatar_url:"order_by",
 		player_country:"order_by",
+		player_custom_avatar_url:"order_by",
 		player_name:"order_by",
 		player_steam_id:"order_by",
 		secondary_value:"order_by",
@@ -8885,6 +8897,7 @@ export const AllTypesProps: Record<string,any> = {
 		checked_in:"Boolean_comparison_exp",
 		discord_id:"String_comparison_exp",
 		id:"uuid_comparison_exp",
+		is_connected:"Boolean_comparison_exp",
 		lineup:"match_lineups_bool_exp",
 		match_lineup_id:"uuid_comparison_exp",
 		party_id:"uuid_comparison_exp",
@@ -8932,6 +8945,7 @@ export const AllTypesProps: Record<string,any> = {
 		checked_in:"order_by",
 		discord_id:"order_by",
 		id:"order_by",
+		is_connected:"order_by",
 		lineup:"match_lineups_order_by",
 		match_lineup_id:"order_by",
 		party_id:"order_by",
@@ -9776,7 +9790,19 @@ export const AllTypesProps: Record<string,any> = {
 		round:"order_by"
 	},
 	match_map_veto_picks_aggregate_bool_exp:{
+		bool_and:"match_map_veto_picks_aggregate_bool_exp_bool_and",
+		bool_or:"match_map_veto_picks_aggregate_bool_exp_bool_or",
 		count:"match_map_veto_picks_aggregate_bool_exp_count"
+	},
+	match_map_veto_picks_aggregate_bool_exp_bool_and:{
+		arguments:"match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns",
+		filter:"match_map_veto_picks_bool_exp",
+		predicate:"Boolean_comparison_exp"
+	},
+	match_map_veto_picks_aggregate_bool_exp_bool_or:{
+		arguments:"match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns",
+		filter:"match_map_veto_picks_bool_exp",
+		predicate:"Boolean_comparison_exp"
 	},
 	match_map_veto_picks_aggregate_bool_exp_count:{
 		arguments:"match_map_veto_picks_select_column",
@@ -9801,6 +9827,7 @@ export const AllTypesProps: Record<string,any> = {
 		_and:"match_map_veto_picks_bool_exp",
 		_not:"match_map_veto_picks_bool_exp",
 		_or:"match_map_veto_picks_bool_exp",
+		auto_picked:"Boolean_comparison_exp",
 		created_at:"timestamptz_comparison_exp",
 		id:"uuid_comparison_exp",
 		map:"maps_bool_exp",
@@ -9846,6 +9873,7 @@ export const AllTypesProps: Record<string,any> = {
 		where:"match_map_veto_picks_bool_exp"
 	},
 	match_map_veto_picks_order_by:{
+		auto_picked:"order_by",
 		created_at:"order_by",
 		id:"order_by",
 		map:"maps_order_by",
@@ -9861,6 +9889,8 @@ export const AllTypesProps: Record<string,any> = {
 		id:"uuid"
 	},
 	match_map_veto_picks_select_column: "enum" as const,
+	match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns: "enum" as const,
+	match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns: "enum" as const,
 	match_map_veto_picks_set_input:{
 		created_at:"timestamptz",
 		id:"uuid",
@@ -10041,6 +10071,7 @@ export const AllTypesProps: Record<string,any> = {
 		_or:"match_maps_bool_exp",
 		clips_count:"Int_comparison_exp",
 		created_at:"timestamptz_comparison_exp",
+		demo_processing_started_at:"timestamptz_comparison_exp",
 		demos:"match_map_demos_bool_exp",
 		demos_aggregate:"match_map_demos_aggregate_bool_exp",
 		demos_download_url:"String_comparison_exp",
@@ -10093,6 +10124,7 @@ export const AllTypesProps: Record<string,any> = {
 	},
 	match_maps_insert_input:{
 		created_at:"timestamptz",
+		demo_processing_started_at:"timestamptz",
 		demos:"match_map_demos_arr_rel_insert_input",
 		e_match_map_status:"e_match_map_status_obj_rel_insert_input",
 		ended_at:"timestamptz",
@@ -10122,6 +10154,7 @@ export const AllTypesProps: Record<string,any> = {
 	match_maps_max_order_by:{
 		clips_count:"order_by",
 		created_at:"order_by",
+		demo_processing_started_at:"order_by",
 		ended_at:"order_by",
 		id:"order_by",
 		latest_clip_at:"order_by",
@@ -10138,6 +10171,7 @@ export const AllTypesProps: Record<string,any> = {
 	match_maps_min_order_by:{
 		clips_count:"order_by",
 		created_at:"order_by",
+		demo_processing_started_at:"order_by",
 		ended_at:"order_by",
 		id:"order_by",
 		latest_clip_at:"order_by",
@@ -10163,6 +10197,7 @@ export const AllTypesProps: Record<string,any> = {
 	match_maps_order_by:{
 		clips_count:"order_by",
 		created_at:"order_by",
+		demo_processing_started_at:"order_by",
 		demos_aggregate:"match_map_demos_aggregate_order_by",
 		demos_download_url:"order_by",
 		demos_total_size:"order_by",
@@ -10204,6 +10239,7 @@ export const AllTypesProps: Record<string,any> = {
 	match_maps_select_column: "enum" as const,
 	match_maps_set_input:{
 		created_at:"timestamptz",
+		demo_processing_started_at:"timestamptz",
 		ended_at:"timestamptz",
 		id:"uuid",
 		latest_clip_at:"timestamptz",
@@ -10243,6 +10279,7 @@ export const AllTypesProps: Record<string,any> = {
 	},
 	match_maps_stream_cursor_value_input:{
 		created_at:"timestamptz",
+		demo_processing_started_at:"timestamptz",
 		ended_at:"timestamptz",
 		id:"uuid",
 		latest_clip_at:"timestamptz",
@@ -10342,7 +10379,8 @@ export const AllTypesProps: Record<string,any> = {
 		tournament_bracket:"tournament_brackets_bool_exp",
 		tournament_stage:"tournament_stages_bool_exp",
 		tv_delay:"Int_comparison_exp",
-		type:"e_match_types_enum_comparison_exp"
+		type:"e_match_types_enum_comparison_exp",
+		veto_pick_timeout:"Int_comparison_exp"
 	},
 	match_options_constraint: "enum" as const,
 	match_options_inc_input:{
@@ -10404,7 +10442,8 @@ export const AllTypesProps: Record<string,any> = {
 		tournament_bracket:"tournament_brackets_order_by",
 		tournament_stage:"tournament_stages_order_by",
 		tv_delay:"order_by",
-		type:"order_by"
+		type:"order_by",
+		veto_pick_timeout:"order_by"
 	},
 	match_options_pk_columns_input:{
 		id:"uuid"
@@ -10441,7 +10480,19 @@ export const AllTypesProps: Record<string,any> = {
 		where:"match_options_bool_exp"
 	},
 	match_region_veto_picks_aggregate_bool_exp:{
+		bool_and:"match_region_veto_picks_aggregate_bool_exp_bool_and",
+		bool_or:"match_region_veto_picks_aggregate_bool_exp_bool_or",
 		count:"match_region_veto_picks_aggregate_bool_exp_count"
+	},
+	match_region_veto_picks_aggregate_bool_exp_bool_and:{
+		arguments:"match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns",
+		filter:"match_region_veto_picks_bool_exp",
+		predicate:"Boolean_comparison_exp"
+	},
+	match_region_veto_picks_aggregate_bool_exp_bool_or:{
+		arguments:"match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns",
+		filter:"match_region_veto_picks_bool_exp",
+		predicate:"Boolean_comparison_exp"
 	},
 	match_region_veto_picks_aggregate_bool_exp_count:{
 		arguments:"match_region_veto_picks_select_column",
@@ -10466,6 +10517,7 @@ export const AllTypesProps: Record<string,any> = {
 		_and:"match_region_veto_picks_bool_exp",
 		_not:"match_region_veto_picks_bool_exp",
 		_or:"match_region_veto_picks_bool_exp",
+		auto_picked:"Boolean_comparison_exp",
 		created_at:"timestamptz_comparison_exp",
 		id:"uuid_comparison_exp",
 		match:"matches_bool_exp",
@@ -10505,6 +10557,7 @@ export const AllTypesProps: Record<string,any> = {
 		where:"match_region_veto_picks_bool_exp"
 	},
 	match_region_veto_picks_order_by:{
+		auto_picked:"order_by",
 		created_at:"order_by",
 		id:"order_by",
 		match:"matches_order_by",
@@ -10518,6 +10571,8 @@ export const AllTypesProps: Record<string,any> = {
 		id:"uuid"
 	},
 	match_region_veto_picks_select_column: "enum" as const,
+	match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns: "enum" as const,
+	match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns: "enum" as const,
 	match_region_veto_picks_set_input:{
 		created_at:"timestamptz",
 		id:"uuid",
@@ -11102,6 +11157,7 @@ export const AllTypesProps: Record<string,any> = {
 		tournament_brackets:"tournament_brackets_bool_exp",
 		tournament_brackets_aggregate:"tournament_brackets_aggregate_bool_exp",
 		tv_connection_string:"String_comparison_exp",
+		veto_pick_expires_at:"timestamptz_comparison_exp",
 		winner:"match_lineups_bool_exp",
 		winning_lineup_id:"uuid_comparison_exp"
 	},
@@ -11146,6 +11202,7 @@ export const AllTypesProps: Record<string,any> = {
 		status:"e_match_status_enum",
 		streams:"match_streams_arr_rel_insert_input",
 		tournament_brackets:"tournament_brackets_arr_rel_insert_input",
+		veto_pick_expires_at:"timestamptz",
 		winner:"match_lineups_obj_rel_insert_input",
 		winning_lineup_id:"uuid"
 	},
@@ -11169,6 +11226,7 @@ export const AllTypesProps: Record<string,any> = {
 		share_code:"order_by",
 		source:"order_by",
 		started_at:"order_by",
+		veto_pick_expires_at:"order_by",
 		winning_lineup_id:"order_by"
 	},
 	matches_min_order_by:{
@@ -11191,6 +11249,7 @@ export const AllTypesProps: Record<string,any> = {
 		share_code:"order_by",
 		source:"order_by",
 		started_at:"order_by",
+		veto_pick_expires_at:"order_by",
 		winning_lineup_id:"order_by"
 	},
 	matches_obj_rel_insert_input:{
@@ -11279,6 +11338,7 @@ export const AllTypesProps: Record<string,any> = {
 		teams_aggregate:"teams_aggregate_order_by",
 		tournament_brackets_aggregate:"tournament_brackets_aggregate_order_by",
 		tv_connection_string:"order_by",
+		veto_pick_expires_at:"order_by",
 		winner:"match_lineups_order_by",
 		winning_lineup_id:"order_by"
 	},
@@ -11299,6 +11359,7 @@ export const AllTypesProps: Record<string,any> = {
 		server_id:"uuid",
 		started_at:"timestamptz",
 		status:"e_match_status_enum",
+		veto_pick_expires_at:"timestamptz",
 		winning_lineup_id:"uuid"
 	},
 	matches_stddev_order_by:{
@@ -11328,6 +11389,7 @@ export const AllTypesProps: Record<string,any> = {
 		server_id:"uuid",
 		started_at:"timestamptz",
 		status:"e_match_status_enum",
+		veto_pick_expires_at:"timestamptz",
 		winning_lineup_id:"uuid"
 	},
 	matches_sum_order_by:{
@@ -12470,6 +12532,9 @@ export const AllTypesProps: Record<string,any> = {
 		},
 		denyInvite:{
 			invite_id:"uuid"
+		},
+		denyNameChange:{
+			steam_id:"bigint"
 		},
 		forfeitMatch:{
 			match_id:"uuid",
@@ -22541,6 +22606,7 @@ export const AllTypesProps: Record<string,any> = {
 		avatar_url:"String_comparison_exp",
 		awards:"award_recipients_bool_exp",
 		awards_aggregate:"award_recipients_aggregate_bool_exp",
+		banned_until:"timestamptz_comparison_exp",
 		coach_lineups:"match_lineups_bool_exp",
 		coach_lineups_aggregate:"match_lineups_aggregate_bool_exp",
 		country:"String_comparison_exp",
@@ -22577,12 +22643,14 @@ export const AllTypesProps: Record<string,any> = {
 		game_ban_count:"Int_comparison_exp",
 		invited_players:"team_invites_bool_exp",
 		invited_players_aggregate:"team_invites_aggregate_bool_exp",
+		is_admin_sanctioned:"Boolean_comparison_exp",
 		is_banned:"Boolean_comparison_exp",
 		is_gagged:"Boolean_comparison_exp",
 		is_in_another_match:"Boolean_comparison_exp",
 		is_in_draft:"Boolean_comparison_exp",
 		is_in_lobby:"Boolean_comparison_exp",
 		is_muted:"Boolean_comparison_exp",
+		is_registered:"Boolean_comparison_exp",
 		kills:"player_kills_bool_exp",
 		kills_aggregate:"player_kills_aggregate_bool_exp",
 		kills_by_weapons:"player_kills_by_weapon_bool_exp",
@@ -22729,6 +22797,7 @@ export const AllTypesProps: Record<string,any> = {
 		assited_by_players_aggregate:"player_assists_aggregate_order_by",
 		avatar_url:"order_by",
 		awards_aggregate:"award_recipients_aggregate_order_by",
+		banned_until:"order_by",
 		coach_lineups_aggregate:"match_lineups_aggregate_order_by",
 		country:"order_by",
 		created_at:"order_by",
@@ -22754,12 +22823,14 @@ export const AllTypesProps: Record<string,any> = {
 		friends_aggregate:"my_friends_aggregate_order_by",
 		game_ban_count:"order_by",
 		invited_players_aggregate:"team_invites_aggregate_order_by",
+		is_admin_sanctioned:"order_by",
 		is_banned:"order_by",
 		is_gagged:"order_by",
 		is_in_another_match:"order_by",
 		is_in_draft:"order_by",
 		is_in_lobby:"order_by",
 		is_muted:"order_by",
+		is_registered:"order_by",
 		kills_aggregate:"player_kills_aggregate_order_by",
 		kills_by_weapons_aggregate:"player_kills_by_weapon_aggregate_order_by",
 		language:"order_by",
@@ -35864,10 +35935,12 @@ export const AllTypesProps: Record<string,any> = {
 		_and:"v_team_ranks_bool_exp",
 		_not:"v_team_ranks_bool_exp",
 		_or:"v_team_ranks_bool_exp",
+		avg_duel_elo:"Int_comparison_exp",
 		avg_elo:"Int_comparison_exp",
 		avg_faceit_elo:"Int_comparison_exp",
 		avg_faceit_level:"float8_comparison_exp",
 		avg_premier:"Int_comparison_exp",
+		avg_wingman_elo:"Int_comparison_exp",
 		max_elo:"Int_comparison_exp",
 		min_elo:"Int_comparison_exp",
 		roster_size:"bigint_comparison_exp",
@@ -35884,10 +35957,12 @@ export const AllTypesProps: Record<string,any> = {
 		data:"v_team_ranks_insert_input"
 	},
 	v_team_ranks_order_by:{
+		avg_duel_elo:"order_by",
 		avg_elo:"order_by",
 		avg_faceit_elo:"order_by",
 		avg_faceit_level:"order_by",
 		avg_premier:"order_by",
+		avg_wingman_elo:"order_by",
 		max_elo:"order_by",
 		min_elo:"order_by",
 		roster_size:"order_by",
@@ -37534,6 +37609,8 @@ export const ReturnTypes: Record<string,any> = {
 	abandoned_matches:{
 		abandoned_at:"timestamptz",
 		id:"uuid",
+		match:"matches",
+		match_id:"uuid",
 		steam_id:"bigint"
 	},
 	abandoned_matches_aggregate:{
@@ -37559,11 +37636,13 @@ export const ReturnTypes: Record<string,any> = {
 	abandoned_matches_max_fields:{
 		abandoned_at:"timestamptz",
 		id:"uuid",
+		match_id:"uuid",
 		steam_id:"bigint"
 	},
 	abandoned_matches_min_fields:{
 		abandoned_at:"timestamptz",
 		id:"uuid",
+		match_id:"uuid",
 		steam_id:"bigint"
 	},
 	abandoned_matches_mutation_response:{
@@ -40600,6 +40679,7 @@ export const ReturnTypes: Record<string,any> = {
 		matches_played:"Int",
 		player_avatar_url:"String",
 		player_country:"String",
+		player_custom_avatar_url:"String",
 		player_name:"String",
 		player_steam_id:"String",
 		secondary_value:"float8",
@@ -40633,6 +40713,7 @@ export const ReturnTypes: Record<string,any> = {
 		matches_played:"Int",
 		player_avatar_url:"String",
 		player_country:"String",
+		player_custom_avatar_url:"String",
 		player_name:"String",
 		player_steam_id:"String",
 		secondary_value:"float8",
@@ -40643,6 +40724,7 @@ export const ReturnTypes: Record<string,any> = {
 		matches_played:"Int",
 		player_avatar_url:"String",
 		player_country:"String",
+		player_custom_avatar_url:"String",
 		player_name:"String",
 		player_steam_id:"String",
 		secondary_value:"float8",
@@ -42040,6 +42122,7 @@ export const ReturnTypes: Record<string,any> = {
 		checked_in:"Boolean",
 		discord_id:"String",
 		id:"uuid",
+		is_connected:"Boolean",
 		lineup:"match_lineups",
 		match_lineup_id:"uuid",
 		party_id:"uuid",
@@ -42491,6 +42574,7 @@ export const ReturnTypes: Record<string,any> = {
 		round:"Float"
 	},
 	match_map_veto_picks:{
+		auto_picked:"Boolean",
 		created_at:"timestamptz",
 		id:"uuid",
 		map:"maps",
@@ -42534,6 +42618,7 @@ export const ReturnTypes: Record<string,any> = {
 	match_maps:{
 		clips_count:"Int",
 		created_at:"timestamptz",
+		demo_processing_started_at:"timestamptz",
 		demos:"match_map_demos",
 		demos_aggregate:"match_map_demos_aggregate",
 		demos_download_url:"String",
@@ -42610,6 +42695,7 @@ export const ReturnTypes: Record<string,any> = {
 	match_maps_max_fields:{
 		clips_count:"Int",
 		created_at:"timestamptz",
+		demo_processing_started_at:"timestamptz",
 		demos_download_url:"String",
 		demos_total_size:"Int",
 		ended_at:"timestamptz",
@@ -42630,6 +42716,7 @@ export const ReturnTypes: Record<string,any> = {
 	match_maps_min_fields:{
 		clips_count:"Int",
 		created_at:"timestamptz",
+		demo_processing_started_at:"timestamptz",
 		demos_download_url:"String",
 		demos_total_size:"Int",
 		ended_at:"timestamptz",
@@ -42754,7 +42841,8 @@ export const ReturnTypes: Record<string,any> = {
 		tournament_bracket:"tournament_brackets",
 		tournament_stage:"tournament_stages",
 		tv_delay:"Int",
-		type:"e_match_types_enum"
+		type:"e_match_types_enum",
+		veto_pick_timeout:"Int"
 	},
 	match_options_aggregate:{
 		aggregate:"match_options_aggregate_fields",
@@ -42780,7 +42868,8 @@ export const ReturnTypes: Record<string,any> = {
 		mr:"Float",
 		number_of_substitutes:"Float",
 		round_restart_delay:"Float",
-		tv_delay:"Float"
+		tv_delay:"Float",
+		veto_pick_timeout:"Float"
 	},
 	match_options_max_fields:{
 		auto_cancel_duration:"Int",
@@ -42793,7 +42882,8 @@ export const ReturnTypes: Record<string,any> = {
 		number_of_substitutes:"Int",
 		regions:"String",
 		round_restart_delay:"Int",
-		tv_delay:"Int"
+		tv_delay:"Int",
+		veto_pick_timeout:"Int"
 	},
 	match_options_min_fields:{
 		auto_cancel_duration:"Int",
@@ -42806,7 +42896,8 @@ export const ReturnTypes: Record<string,any> = {
 		number_of_substitutes:"Int",
 		regions:"String",
 		round_restart_delay:"Int",
-		tv_delay:"Int"
+		tv_delay:"Int",
+		veto_pick_timeout:"Int"
 	},
 	match_options_mutation_response:{
 		affected_rows:"Int",
@@ -42819,7 +42910,8 @@ export const ReturnTypes: Record<string,any> = {
 		mr:"Float",
 		number_of_substitutes:"Float",
 		round_restart_delay:"Float",
-		tv_delay:"Float"
+		tv_delay:"Float",
+		veto_pick_timeout:"Float"
 	},
 	match_options_stddev_pop_fields:{
 		auto_cancel_duration:"Float",
@@ -42828,7 +42920,8 @@ export const ReturnTypes: Record<string,any> = {
 		mr:"Float",
 		number_of_substitutes:"Float",
 		round_restart_delay:"Float",
-		tv_delay:"Float"
+		tv_delay:"Float",
+		veto_pick_timeout:"Float"
 	},
 	match_options_stddev_samp_fields:{
 		auto_cancel_duration:"Float",
@@ -42837,7 +42930,8 @@ export const ReturnTypes: Record<string,any> = {
 		mr:"Float",
 		number_of_substitutes:"Float",
 		round_restart_delay:"Float",
-		tv_delay:"Float"
+		tv_delay:"Float",
+		veto_pick_timeout:"Float"
 	},
 	match_options_sum_fields:{
 		auto_cancel_duration:"Int",
@@ -42846,7 +42940,8 @@ export const ReturnTypes: Record<string,any> = {
 		mr:"Int",
 		number_of_substitutes:"Int",
 		round_restart_delay:"Int",
-		tv_delay:"Int"
+		tv_delay:"Int",
+		veto_pick_timeout:"Int"
 	},
 	match_options_var_pop_fields:{
 		auto_cancel_duration:"Float",
@@ -42855,7 +42950,8 @@ export const ReturnTypes: Record<string,any> = {
 		mr:"Float",
 		number_of_substitutes:"Float",
 		round_restart_delay:"Float",
-		tv_delay:"Float"
+		tv_delay:"Float",
+		veto_pick_timeout:"Float"
 	},
 	match_options_var_samp_fields:{
 		auto_cancel_duration:"Float",
@@ -42864,7 +42960,8 @@ export const ReturnTypes: Record<string,any> = {
 		mr:"Float",
 		number_of_substitutes:"Float",
 		round_restart_delay:"Float",
-		tv_delay:"Float"
+		tv_delay:"Float",
+		veto_pick_timeout:"Float"
 	},
 	match_options_variance_fields:{
 		auto_cancel_duration:"Float",
@@ -42873,9 +42970,11 @@ export const ReturnTypes: Record<string,any> = {
 		mr:"Float",
 		number_of_substitutes:"Float",
 		round_restart_delay:"Float",
-		tv_delay:"Float"
+		tv_delay:"Float",
+		veto_pick_timeout:"Float"
 	},
 	match_region_veto_picks:{
+		auto_picked:"Boolean",
 		created_at:"timestamptz",
 		id:"uuid",
 		match:"matches",
@@ -43122,6 +43221,7 @@ export const ReturnTypes: Record<string,any> = {
 		tournament_brackets:"tournament_brackets",
 		tournament_brackets_aggregate:"tournament_brackets_aggregate",
 		tv_connection_string:"String",
+		veto_pick_expires_at:"timestamptz",
 		winner:"match_lineups",
 		winning_lineup_id:"uuid"
 	},
@@ -43180,6 +43280,7 @@ export const ReturnTypes: Record<string,any> = {
 		source:"String",
 		started_at:"timestamptz",
 		tv_connection_string:"String",
+		veto_pick_expires_at:"timestamptz",
 		winning_lineup_id:"uuid"
 	},
 	matches_min_fields:{
@@ -43215,6 +43316,7 @@ export const ReturnTypes: Record<string,any> = {
 		source:"String",
 		started_at:"timestamptz",
 		tv_connection_string:"String",
+		veto_pick_expires_at:"timestamptz",
 		winning_lineup_id:"uuid"
 	},
 	matches_mutation_response:{
@@ -43632,6 +43734,7 @@ export const ReturnTypes: Record<string,any> = {
 		delete_v_team_stage_results:"v_team_stage_results_mutation_response",
 		delete_v_team_stage_results_by_pk:"v_team_stage_results",
 		denyInvite:"SuccessOutput",
+		denyNameChange:"SuccessOutput",
 		forfeitMatch:"SuccessOutput",
 		getLiveStreamSpecState:"LiveStreamSpecState",
 		getTestUploadLink:"GetTestUploadResponse",
@@ -49733,6 +49836,7 @@ export const ReturnTypes: Record<string,any> = {
 		avatar_url:"String",
 		awards:"award_recipients",
 		awards_aggregate:"award_recipients_aggregate",
+		banned_until:"timestamptz",
 		coach_lineups:"match_lineups",
 		coach_lineups_aggregate:"match_lineups_aggregate",
 		country:"String",
@@ -49769,12 +49873,14 @@ export const ReturnTypes: Record<string,any> = {
 		game_ban_count:"Int",
 		invited_players:"team_invites",
 		invited_players_aggregate:"team_invites_aggregate",
+		is_admin_sanctioned:"Boolean",
 		is_banned:"Boolean",
 		is_gagged:"Boolean",
 		is_in_another_match:"Boolean",
 		is_in_draft:"Boolean",
 		is_in_lobby:"Boolean",
 		is_muted:"Boolean",
+		is_registered:"Boolean",
 		kills:"player_kills",
 		kills_aggregate:"player_kills_aggregate",
 		kills_by_weapons:"player_kills_by_weapon",
@@ -49888,6 +49994,7 @@ export const ReturnTypes: Record<string,any> = {
 	},
 	players_max_fields:{
 		avatar_url:"String",
+		banned_until:"timestamptz",
 		country:"String",
 		created_at:"timestamptz",
 		current_lobby_id:"uuid",
@@ -49925,6 +50032,7 @@ export const ReturnTypes: Record<string,any> = {
 	},
 	players_min_fields:{
 		avatar_url:"String",
+		banned_until:"timestamptz",
 		country:"String",
 		created_at:"timestamptz",
 		current_lobby_id:"uuid",
@@ -57024,10 +57132,12 @@ export const ReturnTypes: Record<string,any> = {
 		total_accounts:"Float"
 	},
 	v_team_ranks:{
+		avg_duel_elo:"Int",
 		avg_elo:"Int",
 		avg_faceit_elo:"Int",
 		avg_faceit_level:"float8",
 		avg_premier:"Int",
+		avg_wingman_elo:"Int",
 		max_elo:"Int",
 		min_elo:"Int",
 		roster_size:"bigint",
@@ -57052,93 +57162,113 @@ export const ReturnTypes: Record<string,any> = {
 		variance:"v_team_ranks_variance_fields"
 	},
 	v_team_ranks_avg_fields:{
+		avg_duel_elo:"Float",
 		avg_elo:"Float",
 		avg_faceit_elo:"Float",
 		avg_faceit_level:"Float",
 		avg_premier:"Float",
+		avg_wingman_elo:"Float",
 		max_elo:"Float",
 		min_elo:"Float",
 		roster_size:"Float"
 	},
 	v_team_ranks_max_fields:{
+		avg_duel_elo:"Int",
 		avg_elo:"Int",
 		avg_faceit_elo:"Int",
 		avg_faceit_level:"float8",
 		avg_premier:"Int",
+		avg_wingman_elo:"Int",
 		max_elo:"Int",
 		min_elo:"Int",
 		roster_size:"bigint",
 		team_id:"uuid"
 	},
 	v_team_ranks_min_fields:{
+		avg_duel_elo:"Int",
 		avg_elo:"Int",
 		avg_faceit_elo:"Int",
 		avg_faceit_level:"float8",
 		avg_premier:"Int",
+		avg_wingman_elo:"Int",
 		max_elo:"Int",
 		min_elo:"Int",
 		roster_size:"bigint",
 		team_id:"uuid"
 	},
 	v_team_ranks_stddev_fields:{
+		avg_duel_elo:"Float",
 		avg_elo:"Float",
 		avg_faceit_elo:"Float",
 		avg_faceit_level:"Float",
 		avg_premier:"Float",
+		avg_wingman_elo:"Float",
 		max_elo:"Float",
 		min_elo:"Float",
 		roster_size:"Float"
 	},
 	v_team_ranks_stddev_pop_fields:{
+		avg_duel_elo:"Float",
 		avg_elo:"Float",
 		avg_faceit_elo:"Float",
 		avg_faceit_level:"Float",
 		avg_premier:"Float",
+		avg_wingman_elo:"Float",
 		max_elo:"Float",
 		min_elo:"Float",
 		roster_size:"Float"
 	},
 	v_team_ranks_stddev_samp_fields:{
+		avg_duel_elo:"Float",
 		avg_elo:"Float",
 		avg_faceit_elo:"Float",
 		avg_faceit_level:"Float",
 		avg_premier:"Float",
+		avg_wingman_elo:"Float",
 		max_elo:"Float",
 		min_elo:"Float",
 		roster_size:"Float"
 	},
 	v_team_ranks_sum_fields:{
+		avg_duel_elo:"Int",
 		avg_elo:"Int",
 		avg_faceit_elo:"Int",
 		avg_faceit_level:"float8",
 		avg_premier:"Int",
+		avg_wingman_elo:"Int",
 		max_elo:"Int",
 		min_elo:"Int",
 		roster_size:"bigint"
 	},
 	v_team_ranks_var_pop_fields:{
+		avg_duel_elo:"Float",
 		avg_elo:"Float",
 		avg_faceit_elo:"Float",
 		avg_faceit_level:"Float",
 		avg_premier:"Float",
+		avg_wingman_elo:"Float",
 		max_elo:"Float",
 		min_elo:"Float",
 		roster_size:"Float"
 	},
 	v_team_ranks_var_samp_fields:{
+		avg_duel_elo:"Float",
 		avg_elo:"Float",
 		avg_faceit_elo:"Float",
 		avg_faceit_level:"Float",
 		avg_premier:"Float",
+		avg_wingman_elo:"Float",
 		max_elo:"Float",
 		min_elo:"Float",
 		roster_size:"Float"
 	},
 	v_team_ranks_variance_fields:{
+		avg_duel_elo:"Float",
 		avg_elo:"Float",
 		avg_faceit_elo:"Float",
 		avg_faceit_level:"Float",
 		avg_premier:"Float",
+		avg_wingman_elo:"Float",
 		max_elo:"Float",
 		min_elo:"Float",
 		roster_size:"Float"

--- a/generated/zeus/index.ts
+++ b/generated/zeus/index.ts
@@ -1848,6 +1848,9 @@ count?: [{	columns?: Array<ValueTypes["_map_pool_select_column"]> | undefined | 
 ["abandoned_matches"]: AliasType<{
 	abandoned_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
+	/** An object relationship */
+	match?:ValueTypes["matches"],
+	match_id?:boolean | `@${string}`,
 	steam_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -1917,6 +1920,8 @@ count?: [{	columns?: Array<ValueTypes["abandoned_matches_select_column"]> | unde
 	_or?: Array<ValueTypes["abandoned_matches_bool_exp"]> | undefined | null | Variable<any, string>,
 	abandoned_at?: ValueTypes["timestamptz_comparison_exp"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid_comparison_exp"] | undefined | null | Variable<any, string>,
+	match?: ValueTypes["matches_bool_exp"] | undefined | null | Variable<any, string>,
+	match_id?: ValueTypes["uuid_comparison_exp"] | undefined | null | Variable<any, string>,
 	steam_id?: ValueTypes["bigint_comparison_exp"] | undefined | null | Variable<any, string>
 };
 	/** unique or primary key constraints on table "abandoned_matches" */
@@ -1929,12 +1934,15 @@ count?: [{	columns?: Array<ValueTypes["abandoned_matches_select_column"]> | unde
 ["abandoned_matches_insert_input"]: {
 	abandoned_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
+	match?: ValueTypes["matches_obj_rel_insert_input"] | undefined | null | Variable<any, string>,
+	match_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	steam_id?: ValueTypes["bigint"] | undefined | null | Variable<any, string>
 };
 	/** aggregate max on columns */
 ["abandoned_matches_max_fields"]: AliasType<{
 	abandoned_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
+	match_id?:boolean | `@${string}`,
 	steam_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -1942,12 +1950,14 @@ count?: [{	columns?: Array<ValueTypes["abandoned_matches_select_column"]> | unde
 ["abandoned_matches_max_order_by"]: {
 	abandoned_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	match_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	steam_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>
 };
 	/** aggregate min on columns */
 ["abandoned_matches_min_fields"]: AliasType<{
 	abandoned_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
+	match_id?:boolean | `@${string}`,
 	steam_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -1955,6 +1965,7 @@ count?: [{	columns?: Array<ValueTypes["abandoned_matches_select_column"]> | unde
 ["abandoned_matches_min_order_by"]: {
 	abandoned_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	match_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	steam_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>
 };
 	/** response of any mutation on the table "abandoned_matches" */
@@ -1975,6 +1986,8 @@ count?: [{	columns?: Array<ValueTypes["abandoned_matches_select_column"]> | unde
 ["abandoned_matches_order_by"]: {
 	abandoned_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	match?: ValueTypes["matches_order_by"] | undefined | null | Variable<any, string>,
+	match_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	steam_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>
 };
 	/** primary key columns input for table: abandoned_matches */
@@ -1987,6 +2000,7 @@ count?: [{	columns?: Array<ValueTypes["abandoned_matches_select_column"]> | unde
 ["abandoned_matches_set_input"]: {
 	abandoned_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
+	match_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	steam_id?: ValueTypes["bigint"] | undefined | null | Variable<any, string>
 };
 	/** aggregate stddev on columns */
@@ -2027,6 +2041,7 @@ count?: [{	columns?: Array<ValueTypes["abandoned_matches_select_column"]> | unde
 ["abandoned_matches_stream_cursor_value_input"]: {
 	abandoned_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
+	match_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	steam_id?: ValueTypes["bigint"] | undefined | null | Variable<any, string>
 };
 	/** aggregate sum on columns */
@@ -13795,6 +13810,7 @@ count?: [{	columns?: Array<ValueTypes["gamedata_signature_validations_select_col
 	_match_type?: string | undefined | null | Variable<any, string>,
 	_role?: string | undefined | null | Variable<any, string>,
 	_season_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
+	_source?: string | undefined | null | Variable<any, string>,
 	_window_days?: number | undefined | null | Variable<any, string>
 };
 	["get_league_season_leaderboard_args"]: {
@@ -13808,6 +13824,7 @@ count?: [{	columns?: Array<ValueTypes["gamedata_signature_validations_select_col
 	_match_type?: string | undefined | null | Variable<any, string>,
 	_player_steam_id?: string | undefined | null | Variable<any, string>,
 	_season_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
+	_source?: string | undefined | null | Variable<any, string>,
 	_window_days?: number | undefined | null | Variable<any, string>
 };
 	["inet"]:unknown;
@@ -13868,6 +13885,7 @@ count?: [{	columns?: Array<ValueTypes["gamedata_signature_validations_select_col
 	matches_played?:boolean | `@${string}`,
 	player_avatar_url?:boolean | `@${string}`,
 	player_country?:boolean | `@${string}`,
+	player_custom_avatar_url?:boolean | `@${string}`,
 	player_name?:boolean | `@${string}`,
 	player_steam_id?:boolean | `@${string}`,
 	secondary_value?:boolean | `@${string}`,
@@ -13911,6 +13929,7 @@ count?: [{	columns?: Array<ValueTypes["leaderboard_entries_select_column"]> | un
 	matches_played?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	player_avatar_url?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
 	player_country?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
+	player_custom_avatar_url?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
 	player_name?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
 	player_steam_id?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
 	secondary_value?: ValueTypes["float8_comparison_exp"] | undefined | null | Variable<any, string>,
@@ -13929,6 +13948,7 @@ count?: [{	columns?: Array<ValueTypes["leaderboard_entries_select_column"]> | un
 	matches_played?: number | undefined | null | Variable<any, string>,
 	player_avatar_url?: string | undefined | null | Variable<any, string>,
 	player_country?: string | undefined | null | Variable<any, string>,
+	player_custom_avatar_url?: string | undefined | null | Variable<any, string>,
 	player_name?: string | undefined | null | Variable<any, string>,
 	player_steam_id?: string | undefined | null | Variable<any, string>,
 	secondary_value?: ValueTypes["float8"] | undefined | null | Variable<any, string>,
@@ -13940,6 +13960,7 @@ count?: [{	columns?: Array<ValueTypes["leaderboard_entries_select_column"]> | un
 	matches_played?:boolean | `@${string}`,
 	player_avatar_url?:boolean | `@${string}`,
 	player_country?:boolean | `@${string}`,
+	player_custom_avatar_url?:boolean | `@${string}`,
 	player_name?:boolean | `@${string}`,
 	player_steam_id?:boolean | `@${string}`,
 	secondary_value?:boolean | `@${string}`,
@@ -13952,6 +13973,7 @@ count?: [{	columns?: Array<ValueTypes["leaderboard_entries_select_column"]> | un
 	matches_played?:boolean | `@${string}`,
 	player_avatar_url?:boolean | `@${string}`,
 	player_country?:boolean | `@${string}`,
+	player_custom_avatar_url?:boolean | `@${string}`,
 	player_name?:boolean | `@${string}`,
 	player_steam_id?:boolean | `@${string}`,
 	secondary_value?:boolean | `@${string}`,
@@ -13972,6 +13994,7 @@ count?: [{	columns?: Array<ValueTypes["leaderboard_entries_select_column"]> | un
 	matches_played?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	player_avatar_url?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	player_country?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	player_custom_avatar_url?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	player_name?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	player_steam_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	secondary_value?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
@@ -13985,6 +14008,7 @@ count?: [{	columns?: Array<ValueTypes["leaderboard_entries_select_column"]> | un
 	matches_played?: number | undefined | null | Variable<any, string>,
 	player_avatar_url?: string | undefined | null | Variable<any, string>,
 	player_country?: string | undefined | null | Variable<any, string>,
+	player_custom_avatar_url?: string | undefined | null | Variable<any, string>,
 	player_name?: string | undefined | null | Variable<any, string>,
 	player_steam_id?: string | undefined | null | Variable<any, string>,
 	secondary_value?: ValueTypes["float8"] | undefined | null | Variable<any, string>,
@@ -14027,6 +14051,7 @@ count?: [{	columns?: Array<ValueTypes["leaderboard_entries_select_column"]> | un
 	matches_played?: number | undefined | null | Variable<any, string>,
 	player_avatar_url?: string | undefined | null | Variable<any, string>,
 	player_country?: string | undefined | null | Variable<any, string>,
+	player_custom_avatar_url?: string | undefined | null | Variable<any, string>,
 	player_name?: string | undefined | null | Variable<any, string>,
 	player_steam_id?: string | undefined | null | Variable<any, string>,
 	secondary_value?: ValueTypes["float8"] | undefined | null | Variable<any, string>,
@@ -18942,6 +18967,7 @@ count?: [{	columns?: Array<ValueTypes["match_demo_sessions_select_column"]> | un
 	checked_in?:boolean | `@${string}`,
 	discord_id?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
+	is_connected?:boolean | `@${string}`,
 	/** An object relationship */
 	lineup?:ValueTypes["match_lineups"],
 	match_lineup_id?:boolean | `@${string}`,
@@ -19035,6 +19061,7 @@ count?: [{	columns?: Array<ValueTypes["match_lineup_players_select_column"]> | u
 	checked_in?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	discord_id?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid_comparison_exp"] | undefined | null | Variable<any, string>,
+	is_connected?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	lineup?: ValueTypes["match_lineups_bool_exp"] | undefined | null | Variable<any, string>,
 	match_lineup_id?: ValueTypes["uuid_comparison_exp"] | undefined | null | Variable<any, string>,
 	party_id?: ValueTypes["uuid_comparison_exp"] | undefined | null | Variable<any, string>,
@@ -19055,6 +19082,7 @@ count?: [{	columns?: Array<ValueTypes["match_lineup_players_select_column"]> | u
 	checked_in?: boolean | undefined | null | Variable<any, string>,
 	discord_id?: string | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
+	is_connected?: boolean | undefined | null | Variable<any, string>,
 	lineup?: ValueTypes["match_lineups_obj_rel_insert_input"] | undefined | null | Variable<any, string>,
 	match_lineup_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	party_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
@@ -19121,6 +19149,7 @@ count?: [{	columns?: Array<ValueTypes["match_lineup_players_select_column"]> | u
 	checked_in?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	discord_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	is_connected?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	lineup?: ValueTypes["match_lineups_order_by"] | undefined | null | Variable<any, string>,
 	match_lineup_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	party_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
@@ -19145,6 +19174,7 @@ count?: [{	columns?: Array<ValueTypes["match_lineup_players_select_column"]> | u
 	checked_in?: boolean | undefined | null | Variable<any, string>,
 	discord_id?: string | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
+	is_connected?: boolean | undefined | null | Variable<any, string>,
 	match_lineup_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	party_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	party_source?: ValueTypes["e_match_party_sources_enum"] | undefined | null | Variable<any, string>,
@@ -19191,6 +19221,7 @@ count?: [{	columns?: Array<ValueTypes["match_lineup_players_select_column"]> | u
 	checked_in?: boolean | undefined | null | Variable<any, string>,
 	discord_id?: string | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
+	is_connected?: boolean | undefined | null | Variable<any, string>,
 	match_lineup_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	party_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	party_source?: ValueTypes["e_match_party_sources_enum"] | undefined | null | Variable<any, string>,
@@ -20685,6 +20716,7 @@ count?: [{	columns?: Array<ValueTypes["match_map_rounds_select_column"]> | undef
 };
 	/** columns and relationships of "match_map_veto_picks" */
 ["match_map_veto_picks"]: AliasType<{
+	auto_picked?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
 	/** An object relationship */
@@ -20707,7 +20739,21 @@ count?: [{	columns?: Array<ValueTypes["match_map_rounds_select_column"]> | undef
 		__typename?: boolean | `@${string}`
 }>;
 	["match_map_veto_picks_aggregate_bool_exp"]: {
+	bool_and?: ValueTypes["match_map_veto_picks_aggregate_bool_exp_bool_and"] | undefined | null | Variable<any, string>,
+	bool_or?: ValueTypes["match_map_veto_picks_aggregate_bool_exp_bool_or"] | undefined | null | Variable<any, string>,
 	count?: ValueTypes["match_map_veto_picks_aggregate_bool_exp_count"] | undefined | null | Variable<any, string>
+};
+	["match_map_veto_picks_aggregate_bool_exp_bool_and"]: {
+	arguments: ValueTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"] | Variable<any, string>,
+	distinct?: boolean | undefined | null | Variable<any, string>,
+	filter?: ValueTypes["match_map_veto_picks_bool_exp"] | undefined | null | Variable<any, string>,
+	predicate: ValueTypes["Boolean_comparison_exp"] | Variable<any, string>
+};
+	["match_map_veto_picks_aggregate_bool_exp_bool_or"]: {
+	arguments: ValueTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"] | Variable<any, string>,
+	distinct?: boolean | undefined | null | Variable<any, string>,
+	filter?: ValueTypes["match_map_veto_picks_bool_exp"] | undefined | null | Variable<any, string>,
+	predicate: ValueTypes["Boolean_comparison_exp"] | Variable<any, string>
 };
 	["match_map_veto_picks_aggregate_bool_exp_count"]: {
 	arguments?: Array<ValueTypes["match_map_veto_picks_select_column"]> | undefined | null | Variable<any, string>,
@@ -20739,6 +20785,7 @@ count?: [{	columns?: Array<ValueTypes["match_map_veto_picks_select_column"]> | u
 	_and?: Array<ValueTypes["match_map_veto_picks_bool_exp"]> | undefined | null | Variable<any, string>,
 	_not?: ValueTypes["match_map_veto_picks_bool_exp"] | undefined | null | Variable<any, string>,
 	_or?: Array<ValueTypes["match_map_veto_picks_bool_exp"]> | undefined | null | Variable<any, string>,
+	auto_picked?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz_comparison_exp"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid_comparison_exp"] | undefined | null | Variable<any, string>,
 	map?: ValueTypes["maps_bool_exp"] | undefined | null | Variable<any, string>,
@@ -20754,6 +20801,7 @@ count?: [{	columns?: Array<ValueTypes["match_map_veto_picks_select_column"]> | u
 ["match_map_veto_picks_constraint"]:match_map_veto_picks_constraint;
 	/** input type for inserting data into table "match_map_veto_picks" */
 ["match_map_veto_picks_insert_input"]: {
+	auto_picked?: boolean | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	map?: ValueTypes["maps_obj_rel_insert_input"] | undefined | null | Variable<any, string>,
@@ -20819,6 +20867,7 @@ count?: [{	columns?: Array<ValueTypes["match_map_veto_picks_select_column"]> | u
 };
 	/** Ordering options when selecting data from "match_map_veto_picks". */
 ["match_map_veto_picks_order_by"]: {
+	auto_picked?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	map?: ValueTypes["maps_order_by"] | undefined | null | Variable<any, string>,
@@ -20836,8 +20885,13 @@ count?: [{	columns?: Array<ValueTypes["match_map_veto_picks_select_column"]> | u
 };
 	/** select columns of table "match_map_veto_picks" */
 ["match_map_veto_picks_select_column"]:match_map_veto_picks_select_column;
+	/** select "match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_map_veto_picks" */
+["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]:match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns;
+	/** select "match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_map_veto_picks" */
+["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]:match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns;
 	/** input type for updating data in table "match_map_veto_picks" */
 ["match_map_veto_picks_set_input"]: {
+	auto_picked?: boolean | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	map_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
@@ -20855,6 +20909,7 @@ count?: [{	columns?: Array<ValueTypes["match_map_veto_picks_select_column"]> | u
 };
 	/** Initial value of the column from where the streaming should start */
 ["match_map_veto_picks_stream_cursor_value_input"]: {
+	auto_picked?: boolean | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	map_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
@@ -20875,6 +20930,7 @@ count?: [{	columns?: Array<ValueTypes["match_map_veto_picks_select_column"]> | u
 ["match_maps"]: AliasType<{
 	clips_count?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
+	demo_processing_started_at?:boolean | `@${string}`,
 demos?: [{	/** distinct select on columns */
 	distinct_on?: Array<ValueTypes["match_map_demos_select_column"]> | undefined | null | Variable<any, string>,	/** limit the number of rows returned */
 	limit?: number | undefined | null | Variable<any, string>,	/** skip the first n rows. Use only with order_by */
@@ -21120,6 +21176,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 	_or?: Array<ValueTypes["match_maps_bool_exp"]> | undefined | null | Variable<any, string>,
 	clips_count?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz_comparison_exp"] | undefined | null | Variable<any, string>,
+	demo_processing_started_at?: ValueTypes["timestamptz_comparison_exp"] | undefined | null | Variable<any, string>,
 	demos?: ValueTypes["match_map_demos_bool_exp"] | undefined | null | Variable<any, string>,
 	demos_aggregate?: ValueTypes["match_map_demos_aggregate_bool_exp"] | undefined | null | Variable<any, string>,
 	demos_download_url?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
@@ -21180,6 +21237,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 ["match_maps_insert_input"]: {
 	clips_count?: number | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
+	demo_processing_started_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	demos?: ValueTypes["match_map_demos_arr_rel_insert_input"] | undefined | null | Variable<any, string>,
 	e_match_map_status?: ValueTypes["e_match_map_status_obj_rel_insert_input"] | undefined | null | Variable<any, string>,
 	ended_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
@@ -21214,6 +21272,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 ["match_maps_max_fields"]: AliasType<{
 	clips_count?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
+	demo_processing_started_at?:boolean | `@${string}`,
 	/** A computed field, executes function "match_map_demo_download_url" */
 	demos_download_url?:boolean | `@${string}`,
 	/** A computed field, executes function "match_map_demo_total_size" */
@@ -21240,6 +21299,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 ["match_maps_max_order_by"]: {
 	clips_count?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	demo_processing_started_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	ended_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	latest_clip_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
@@ -21257,6 +21317,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 ["match_maps_min_fields"]: AliasType<{
 	clips_count?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
+	demo_processing_started_at?:boolean | `@${string}`,
 	/** A computed field, executes function "match_map_demo_download_url" */
 	demos_download_url?:boolean | `@${string}`,
 	/** A computed field, executes function "match_map_demo_total_size" */
@@ -21283,6 +21344,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 ["match_maps_min_order_by"]: {
 	clips_count?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	demo_processing_started_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	ended_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	latest_clip_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
@@ -21320,6 +21382,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 ["match_maps_order_by"]: {
 	clips_count?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	demo_processing_started_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	demos_aggregate?: ValueTypes["match_map_demos_aggregate_order_by"] | undefined | null | Variable<any, string>,
 	demos_download_url?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	demos_total_size?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
@@ -21365,6 +21428,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 ["match_maps_set_input"]: {
 	clips_count?: number | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
+	demo_processing_started_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	ended_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	latest_clip_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
@@ -21461,6 +21525,7 @@ count?: [{	columns?: Array<ValueTypes["match_maps_select_column"]> | undefined |
 ["match_maps_stream_cursor_value_input"]: {
 	clips_count?: number | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
+	demo_processing_started_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	ended_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	latest_clip_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
@@ -21629,6 +21694,7 @@ matches_aggregate?: [{	/** distinct select on columns */
 	tournament_stage?:ValueTypes["tournament_stages"],
 	tv_delay?:boolean | `@${string}`,
 	type?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregated selection of "match_options" */
@@ -21661,6 +21727,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** Boolean expression to filter rows from the table "match_options". All fields are combined with a logical 'AND'. */
@@ -21700,7 +21767,8 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	tournament_bracket?: ValueTypes["tournament_brackets_bool_exp"] | undefined | null | Variable<any, string>,
 	tournament_stage?: ValueTypes["tournament_stages_bool_exp"] | undefined | null | Variable<any, string>,
 	tv_delay?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
-	type?: ValueTypes["e_match_types_enum_comparison_exp"] | undefined | null | Variable<any, string>
+	type?: ValueTypes["e_match_types_enum_comparison_exp"] | undefined | null | Variable<any, string>,
+	veto_pick_timeout?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>
 };
 	/** unique or primary key constraints on table "match_options" */
 ["match_options_constraint"]:match_options_constraint;
@@ -21712,7 +21780,8 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	mr?: number | undefined | null | Variable<any, string>,
 	number_of_substitutes?: number | undefined | null | Variable<any, string>,
 	round_restart_delay?: number | undefined | null | Variable<any, string>,
-	tv_delay?: number | undefined | null | Variable<any, string>
+	tv_delay?: number | undefined | null | Variable<any, string>,
+	veto_pick_timeout?: number | undefined | null | Variable<any, string>
 };
 	/** input type for inserting data into table "match_options" */
 ["match_options_insert_input"]: {
@@ -21746,7 +21815,8 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	tournament_bracket?: ValueTypes["tournament_brackets_obj_rel_insert_input"] | undefined | null | Variable<any, string>,
 	tournament_stage?: ValueTypes["tournament_stages_obj_rel_insert_input"] | undefined | null | Variable<any, string>,
 	tv_delay?: number | undefined | null | Variable<any, string>,
-	type?: ValueTypes["e_match_types_enum"] | undefined | null | Variable<any, string>
+	type?: ValueTypes["e_match_types_enum"] | undefined | null | Variable<any, string>,
+	veto_pick_timeout?: number | undefined | null | Variable<any, string>
 };
 	/** aggregate max on columns */
 ["match_options_max_fields"]: AliasType<{
@@ -21761,6 +21831,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	regions?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate min on columns */
@@ -21776,6 +21847,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	regions?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** response of any mutation on the table "match_options" */
@@ -21831,7 +21903,8 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	tournament_bracket?: ValueTypes["tournament_brackets_order_by"] | undefined | null | Variable<any, string>,
 	tournament_stage?: ValueTypes["tournament_stages_order_by"] | undefined | null | Variable<any, string>,
 	tv_delay?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
-	type?: ValueTypes["order_by"] | undefined | null | Variable<any, string>
+	type?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	veto_pick_timeout?: ValueTypes["order_by"] | undefined | null | Variable<any, string>
 };
 	/** primary key columns input for table: match_options */
 ["match_options_pk_columns_input"]: {
@@ -21866,7 +21939,8 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	tech_timeout_setting?: ValueTypes["e_timeout_settings_enum"] | undefined | null | Variable<any, string>,
 	timeout_setting?: ValueTypes["e_timeout_settings_enum"] | undefined | null | Variable<any, string>,
 	tv_delay?: number | undefined | null | Variable<any, string>,
-	type?: ValueTypes["e_match_types_enum"] | undefined | null | Variable<any, string>
+	type?: ValueTypes["e_match_types_enum"] | undefined | null | Variable<any, string>,
+	veto_pick_timeout?: number | undefined | null | Variable<any, string>
 };
 	/** aggregate stddev on columns */
 ["match_options_stddev_fields"]: AliasType<{
@@ -21877,6 +21951,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate stddev_pop on columns */
@@ -21888,6 +21963,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate stddev_samp on columns */
@@ -21899,6 +21975,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** Streaming cursor of the table "match_options" */
@@ -21935,7 +22012,8 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	tech_timeout_setting?: ValueTypes["e_timeout_settings_enum"] | undefined | null | Variable<any, string>,
 	timeout_setting?: ValueTypes["e_timeout_settings_enum"] | undefined | null | Variable<any, string>,
 	tv_delay?: number | undefined | null | Variable<any, string>,
-	type?: ValueTypes["e_match_types_enum"] | undefined | null | Variable<any, string>
+	type?: ValueTypes["e_match_types_enum"] | undefined | null | Variable<any, string>,
+	veto_pick_timeout?: number | undefined | null | Variable<any, string>
 };
 	/** aggregate sum on columns */
 ["match_options_sum_fields"]: AliasType<{
@@ -21946,6 +22024,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** update columns of table "match_options" */
@@ -21967,6 +22046,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate var_samp on columns */
@@ -21978,6 +22058,7 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate variance on columns */
@@ -21989,10 +22070,12 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** columns and relationships of "match_region_veto_picks" */
 ["match_region_veto_picks"]: AliasType<{
+	auto_picked?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
 	/** An object relationship */
@@ -22012,7 +22095,21 @@ count?: [{	columns?: Array<ValueTypes["match_options_select_column"]> | undefine
 		__typename?: boolean | `@${string}`
 }>;
 	["match_region_veto_picks_aggregate_bool_exp"]: {
+	bool_and?: ValueTypes["match_region_veto_picks_aggregate_bool_exp_bool_and"] | undefined | null | Variable<any, string>,
+	bool_or?: ValueTypes["match_region_veto_picks_aggregate_bool_exp_bool_or"] | undefined | null | Variable<any, string>,
 	count?: ValueTypes["match_region_veto_picks_aggregate_bool_exp_count"] | undefined | null | Variable<any, string>
+};
+	["match_region_veto_picks_aggregate_bool_exp_bool_and"]: {
+	arguments: ValueTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"] | Variable<any, string>,
+	distinct?: boolean | undefined | null | Variable<any, string>,
+	filter?: ValueTypes["match_region_veto_picks_bool_exp"] | undefined | null | Variable<any, string>,
+	predicate: ValueTypes["Boolean_comparison_exp"] | Variable<any, string>
+};
+	["match_region_veto_picks_aggregate_bool_exp_bool_or"]: {
+	arguments: ValueTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"] | Variable<any, string>,
+	distinct?: boolean | undefined | null | Variable<any, string>,
+	filter?: ValueTypes["match_region_veto_picks_bool_exp"] | undefined | null | Variable<any, string>,
+	predicate: ValueTypes["Boolean_comparison_exp"] | Variable<any, string>
 };
 	["match_region_veto_picks_aggregate_bool_exp_count"]: {
 	arguments?: Array<ValueTypes["match_region_veto_picks_select_column"]> | undefined | null | Variable<any, string>,
@@ -22044,6 +22141,7 @@ count?: [{	columns?: Array<ValueTypes["match_region_veto_picks_select_column"]> 
 	_and?: Array<ValueTypes["match_region_veto_picks_bool_exp"]> | undefined | null | Variable<any, string>,
 	_not?: ValueTypes["match_region_veto_picks_bool_exp"] | undefined | null | Variable<any, string>,
 	_or?: Array<ValueTypes["match_region_veto_picks_bool_exp"]> | undefined | null | Variable<any, string>,
+	auto_picked?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz_comparison_exp"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid_comparison_exp"] | undefined | null | Variable<any, string>,
 	match?: ValueTypes["matches_bool_exp"] | undefined | null | Variable<any, string>,
@@ -22057,6 +22155,7 @@ count?: [{	columns?: Array<ValueTypes["match_region_veto_picks_select_column"]> 
 ["match_region_veto_picks_constraint"]:match_region_veto_picks_constraint;
 	/** input type for inserting data into table "match_region_veto_picks" */
 ["match_region_veto_picks_insert_input"]: {
+	auto_picked?: boolean | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	match?: ValueTypes["matches_obj_rel_insert_input"] | undefined | null | Variable<any, string>,
@@ -22116,6 +22215,7 @@ count?: [{	columns?: Array<ValueTypes["match_region_veto_picks_select_column"]> 
 };
 	/** Ordering options when selecting data from "match_region_veto_picks". */
 ["match_region_veto_picks_order_by"]: {
+	auto_picked?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	match?: ValueTypes["matches_order_by"] | undefined | null | Variable<any, string>,
@@ -22131,8 +22231,13 @@ count?: [{	columns?: Array<ValueTypes["match_region_veto_picks_select_column"]> 
 };
 	/** select columns of table "match_region_veto_picks" */
 ["match_region_veto_picks_select_column"]:match_region_veto_picks_select_column;
+	/** select "match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_region_veto_picks" */
+["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]:match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns;
+	/** select "match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_region_veto_picks" */
+["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]:match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns;
 	/** input type for updating data in table "match_region_veto_picks" */
 ["match_region_veto_picks_set_input"]: {
+	auto_picked?: boolean | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	match_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
@@ -22149,6 +22254,7 @@ count?: [{	columns?: Array<ValueTypes["match_region_veto_picks_select_column"]> 
 };
 	/** Initial value of the column from where the streaming should start */
 ["match_region_veto_picks_stream_cursor_value_input"]: {
+	auto_picked?: boolean | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
 	match_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>,
@@ -22970,6 +23076,7 @@ tournament_brackets_aggregate?: [{	/** distinct select on columns */
 	where?: ValueTypes["tournament_brackets_bool_exp"] | undefined | null | Variable<any, string>},ValueTypes["tournament_brackets_aggregate"]],
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?:boolean | `@${string}`,
+	veto_pick_expires_at?:boolean | `@${string}`,
 	/** An object relationship */
 	winner?:ValueTypes["match_lineups"],
 	winning_lineup_id?:boolean | `@${string}`,
@@ -23136,6 +23243,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	tournament_brackets?: ValueTypes["tournament_brackets_bool_exp"] | undefined | null | Variable<any, string>,
 	tournament_brackets_aggregate?: ValueTypes["tournament_brackets_aggregate_bool_exp"] | undefined | null | Variable<any, string>,
 	tv_connection_string?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
+	veto_pick_expires_at?: ValueTypes["timestamptz_comparison_exp"] | undefined | null | Variable<any, string>,
 	winner?: ValueTypes["match_lineups_bool_exp"] | undefined | null | Variable<any, string>,
 	winning_lineup_id?: ValueTypes["uuid_comparison_exp"] | undefined | null | Variable<any, string>
 };
@@ -23190,6 +23298,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	status?: ValueTypes["e_match_status_enum"] | undefined | null | Variable<any, string>,
 	streams?: ValueTypes["match_streams_arr_rel_insert_input"] | undefined | null | Variable<any, string>,
 	tournament_brackets?: ValueTypes["tournament_brackets_arr_rel_insert_input"] | undefined | null | Variable<any, string>,
+	veto_pick_expires_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	winner?: ValueTypes["match_lineups_obj_rel_insert_input"] | undefined | null | Variable<any, string>,
 	winning_lineup_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>
 };
@@ -23240,6 +23349,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	started_at?:boolean | `@${string}`,
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?:boolean | `@${string}`,
+	veto_pick_expires_at?:boolean | `@${string}`,
 	winning_lineup_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -23264,6 +23374,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	share_code?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	source?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	started_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	veto_pick_expires_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	winning_lineup_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>
 };
 	/** aggregate min on columns */
@@ -23313,6 +23424,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	started_at?:boolean | `@${string}`,
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?:boolean | `@${string}`,
+	veto_pick_expires_at?:boolean | `@${string}`,
 	winning_lineup_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -23337,6 +23449,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	share_code?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	source?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	started_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	veto_pick_expires_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	winning_lineup_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>
 };
 	/** response of any mutation on the table "matches" */
@@ -23437,6 +23550,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	teams_aggregate?: ValueTypes["teams_aggregate_order_by"] | undefined | null | Variable<any, string>,
 	tournament_brackets_aggregate?: ValueTypes["tournament_brackets_aggregate_order_by"] | undefined | null | Variable<any, string>,
 	tv_connection_string?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	veto_pick_expires_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	winner?: ValueTypes["match_lineups_order_by"] | undefined | null | Variable<any, string>,
 	winning_lineup_id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>
 };
@@ -23467,6 +23581,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	source?: string | undefined | null | Variable<any, string>,
 	started_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	status?: ValueTypes["e_match_status_enum"] | undefined | null | Variable<any, string>,
+	veto_pick_expires_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	winning_lineup_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>
 };
 	/** aggregate stddev on columns */
@@ -23537,6 +23652,7 @@ count?: [{	columns?: Array<ValueTypes["matches_select_column"]> | undefined | nu
 	source?: string | undefined | null | Variable<any, string>,
 	started_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	status?: ValueTypes["e_match_status_enum"] | undefined | null | Variable<any, string>,
+	veto_pick_expires_at?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>,
 	winning_lineup_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>
 };
 	/** aggregate sum on columns */
@@ -24226,6 +24342,7 @@ delete_v_team_stage_results?: [{	/** filter the rows which have to be deleted */
 	where: ValueTypes["v_team_stage_results_bool_exp"] | Variable<any, string>},ValueTypes["v_team_stage_results_mutation_response"]],
 delete_v_team_stage_results_by_pk?: [{	tournament_stage_id: ValueTypes["uuid"] | Variable<any, string>,	tournament_team_id: ValueTypes["uuid"] | Variable<any, string>},ValueTypes["v_team_stage_results"]],
 denyInvite?: [{	invite_id: ValueTypes["uuid"] | Variable<any, string>,	type: string | Variable<any, string>},ValueTypes["SuccessOutput"]],
+denyNameChange?: [{	name: string | Variable<any, string>,	steam_id: ValueTypes["bigint"] | Variable<any, string>},ValueTypes["SuccessOutput"]],
 forfeitMatch?: [{	match_id: ValueTypes["uuid"] | Variable<any, string>,	winning_lineup_id: ValueTypes["uuid"] | Variable<any, string>},ValueTypes["SuccessOutput"]],
 getLiveStreamSpecState?: [{	match_id: ValueTypes["uuid"] | Variable<any, string>},ValueTypes["LiveStreamSpecState"]],
 	getTestUploadLink?:ValueTypes["GetTestUploadResponse"],
@@ -40500,6 +40617,8 @@ awards_aggregate?: [{	/** distinct select on columns */
 	offset?: number | undefined | null | Variable<any, string>,	/** sort the rows by one or more columns */
 	order_by?: Array<ValueTypes["award_recipients_order_by"]> | undefined | null | Variable<any, string>,	/** filter the rows returned */
 	where?: ValueTypes["award_recipients_bool_exp"] | undefined | null | Variable<any, string>},ValueTypes["award_recipients_aggregate"]],
+	/** A computed field, executes function "banned_until" */
+	banned_until?:boolean | `@${string}`,
 coach_lineups?: [{	/** distinct select on columns */
 	distinct_on?: Array<ValueTypes["match_lineups_select_column"]> | undefined | null | Variable<any, string>,	/** limit the number of rows returned */
 	limit?: number | undefined | null | Variable<any, string>,	/** skip the first n rows. Use only with order_by */
@@ -40648,6 +40767,8 @@ invited_players_aggregate?: [{	/** distinct select on columns */
 	offset?: number | undefined | null | Variable<any, string>,	/** sort the rows by one or more columns */
 	order_by?: Array<ValueTypes["team_invites_order_by"]> | undefined | null | Variable<any, string>,	/** filter the rows returned */
 	where?: ValueTypes["team_invites_bool_exp"] | undefined | null | Variable<any, string>},ValueTypes["team_invites_aggregate"]],
+	/** A computed field, executes function "is_admin_sanctioned" */
+	is_admin_sanctioned?:boolean | `@${string}`,
 	/** A computed field, executes function "is_banned" */
 	is_banned?:boolean | `@${string}`,
 	/** A computed field, executes function "is_gagged" */
@@ -40660,6 +40781,8 @@ invited_players_aggregate?: [{	/** distinct select on columns */
 	is_in_lobby?:boolean | `@${string}`,
 	/** A computed field, executes function "is_muted" */
 	is_muted?:boolean | `@${string}`,
+	/** A computed field, executes function "is_registered" */
+	is_registered?:boolean | `@${string}`,
 kills?: [{	/** distinct select on columns */
 	distinct_on?: Array<ValueTypes["player_kills_select_column"]> | undefined | null | Variable<any, string>,	/** limit the number of rows returned */
 	limit?: number | undefined | null | Variable<any, string>,	/** skip the first n rows. Use only with order_by */
@@ -41055,6 +41178,7 @@ count?: [{	columns?: Array<ValueTypes["players_select_column"]> | undefined | nu
 	avatar_url?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
 	awards?: ValueTypes["award_recipients_bool_exp"] | undefined | null | Variable<any, string>,
 	awards_aggregate?: ValueTypes["award_recipients_aggregate_bool_exp"] | undefined | null | Variable<any, string>,
+	banned_until?: ValueTypes["timestamptz_comparison_exp"] | undefined | null | Variable<any, string>,
 	coach_lineups?: ValueTypes["match_lineups_bool_exp"] | undefined | null | Variable<any, string>,
 	coach_lineups_aggregate?: ValueTypes["match_lineups_aggregate_bool_exp"] | undefined | null | Variable<any, string>,
 	country?: ValueTypes["String_comparison_exp"] | undefined | null | Variable<any, string>,
@@ -41091,12 +41215,14 @@ count?: [{	columns?: Array<ValueTypes["players_select_column"]> | undefined | nu
 	game_ban_count?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	invited_players?: ValueTypes["team_invites_bool_exp"] | undefined | null | Variable<any, string>,
 	invited_players_aggregate?: ValueTypes["team_invites_aggregate_bool_exp"] | undefined | null | Variable<any, string>,
+	is_admin_sanctioned?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	is_banned?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	is_gagged?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	is_in_another_match?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	is_in_draft?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	is_in_lobby?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	is_muted?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
+	is_registered?: ValueTypes["Boolean_comparison_exp"] | undefined | null | Variable<any, string>,
 	kills?: ValueTypes["player_kills_bool_exp"] | undefined | null | Variable<any, string>,
 	kills_aggregate?: ValueTypes["player_kills_aggregate_bool_exp"] | undefined | null | Variable<any, string>,
 	kills_by_weapons?: ValueTypes["player_kills_by_weapon_bool_exp"] | undefined | null | Variable<any, string>,
@@ -41259,6 +41385,8 @@ count?: [{	columns?: Array<ValueTypes["players_select_column"]> | undefined | nu
 	/** aggregate max on columns */
 ["players_max_fields"]: AliasType<{
 	avatar_url?:boolean | `@${string}`,
+	/** A computed field, executes function "banned_until" */
+	banned_until?:boolean | `@${string}`,
 	country?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
 	/** A computed field, executes function "get_player_current_lobby_id" */
@@ -41309,6 +41437,8 @@ count?: [{	columns?: Array<ValueTypes["players_select_column"]> | undefined | nu
 	/** aggregate min on columns */
 ["players_min_fields"]: AliasType<{
 	avatar_url?:boolean | `@${string}`,
+	/** A computed field, executes function "banned_until" */
+	banned_until?:boolean | `@${string}`,
 	country?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
 	/** A computed field, executes function "get_player_current_lobby_id" */
@@ -41384,6 +41514,7 @@ count?: [{	columns?: Array<ValueTypes["players_select_column"]> | undefined | nu
 	assited_by_players_aggregate?: ValueTypes["player_assists_aggregate_order_by"] | undefined | null | Variable<any, string>,
 	avatar_url?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	awards_aggregate?: ValueTypes["award_recipients_aggregate_order_by"] | undefined | null | Variable<any, string>,
+	banned_until?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	coach_lineups_aggregate?: ValueTypes["match_lineups_aggregate_order_by"] | undefined | null | Variable<any, string>,
 	country?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	created_at?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
@@ -41409,12 +41540,14 @@ count?: [{	columns?: Array<ValueTypes["players_select_column"]> | undefined | nu
 	friends_aggregate?: ValueTypes["my_friends_aggregate_order_by"] | undefined | null | Variable<any, string>,
 	game_ban_count?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	invited_players_aggregate?: ValueTypes["team_invites_aggregate_order_by"] | undefined | null | Variable<any, string>,
+	is_admin_sanctioned?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	is_banned?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	is_gagged?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	is_in_another_match?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	is_in_draft?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	is_in_lobby?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	is_muted?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	is_registered?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	kills_aggregate?: ValueTypes["player_kills_aggregate_order_by"] | undefined | null | Variable<any, string>,
 	kills_by_weapons_aggregate?: ValueTypes["player_kills_by_weapon_aggregate_order_by"] | undefined | null | Variable<any, string>,
 	language?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
@@ -63699,10 +63832,12 @@ count?: [{	columns?: Array<ValueTypes["v_steam_account_pool_status_select_column
 }>;
 	/** columns and relationships of "v_team_ranks" */
 ["v_team_ranks"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63734,10 +63869,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 }>;
 	/** aggregate avg on columns */
 ["v_team_ranks_avg_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63748,10 +63885,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 	_and?: Array<ValueTypes["v_team_ranks_bool_exp"]> | undefined | null | Variable<any, string>,
 	_not?: ValueTypes["v_team_ranks_bool_exp"] | undefined | null | Variable<any, string>,
 	_or?: Array<ValueTypes["v_team_ranks_bool_exp"]> | undefined | null | Variable<any, string>,
+	avg_duel_elo?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	avg_elo?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	avg_faceit_elo?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	avg_faceit_level?: ValueTypes["float8_comparison_exp"] | undefined | null | Variable<any, string>,
 	avg_premier?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
+	avg_wingman_elo?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	max_elo?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	min_elo?: ValueTypes["Int_comparison_exp"] | undefined | null | Variable<any, string>,
 	roster_size?: ValueTypes["bigint_comparison_exp"] | undefined | null | Variable<any, string>,
@@ -63760,10 +63899,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 };
 	/** input type for inserting data into table "v_team_ranks" */
 ["v_team_ranks_insert_input"]: {
+	avg_duel_elo?: number | undefined | null | Variable<any, string>,
 	avg_elo?: number | undefined | null | Variable<any, string>,
 	avg_faceit_elo?: number | undefined | null | Variable<any, string>,
 	avg_faceit_level?: ValueTypes["float8"] | undefined | null | Variable<any, string>,
 	avg_premier?: number | undefined | null | Variable<any, string>,
+	avg_wingman_elo?: number | undefined | null | Variable<any, string>,
 	max_elo?: number | undefined | null | Variable<any, string>,
 	min_elo?: number | undefined | null | Variable<any, string>,
 	roster_size?: ValueTypes["bigint"] | undefined | null | Variable<any, string>,
@@ -63772,10 +63913,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 };
 	/** aggregate max on columns */
 ["v_team_ranks_max_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63784,10 +63927,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 }>;
 	/** aggregate min on columns */
 ["v_team_ranks_min_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63800,10 +63945,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 };
 	/** Ordering options when selecting data from "v_team_ranks". */
 ["v_team_ranks_order_by"]: {
+	avg_duel_elo?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	avg_elo?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	avg_faceit_elo?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	avg_faceit_level?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	avg_premier?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
+	avg_wingman_elo?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	max_elo?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	min_elo?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
 	roster_size?: ValueTypes["order_by"] | undefined | null | Variable<any, string>,
@@ -63814,10 +63961,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 ["v_team_ranks_select_column"]:v_team_ranks_select_column;
 	/** aggregate stddev on columns */
 ["v_team_ranks_stddev_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63825,10 +63974,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 }>;
 	/** aggregate stddev_pop on columns */
 ["v_team_ranks_stddev_pop_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63836,10 +63987,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 }>;
 	/** aggregate stddev_samp on columns */
 ["v_team_ranks_stddev_samp_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63854,10 +64007,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 };
 	/** Initial value of the column from where the streaming should start */
 ["v_team_ranks_stream_cursor_value_input"]: {
+	avg_duel_elo?: number | undefined | null | Variable<any, string>,
 	avg_elo?: number | undefined | null | Variable<any, string>,
 	avg_faceit_elo?: number | undefined | null | Variable<any, string>,
 	avg_faceit_level?: ValueTypes["float8"] | undefined | null | Variable<any, string>,
 	avg_premier?: number | undefined | null | Variable<any, string>,
+	avg_wingman_elo?: number | undefined | null | Variable<any, string>,
 	max_elo?: number | undefined | null | Variable<any, string>,
 	min_elo?: number | undefined | null | Variable<any, string>,
 	roster_size?: ValueTypes["bigint"] | undefined | null | Variable<any, string>,
@@ -63865,10 +64020,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 };
 	/** aggregate sum on columns */
 ["v_team_ranks_sum_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63876,10 +64033,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 }>;
 	/** aggregate var_pop on columns */
 ["v_team_ranks_var_pop_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63887,10 +64046,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 }>;
 	/** aggregate var_samp on columns */
 ["v_team_ranks_var_samp_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -63898,10 +64059,12 @@ count?: [{	columns?: Array<ValueTypes["v_team_ranks_select_column"]> | undefined
 }>;
 	/** aggregate variance on columns */
 ["v_team_ranks_variance_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -66774,6 +66937,9 @@ count?: [{	columns?: Array<ResolverInputTypes["_map_pool_select_column"]> | unde
 ["abandoned_matches"]: AliasType<{
 	abandoned_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
+	/** An object relationship */
+	match?:ResolverInputTypes["matches"],
+	match_id?:boolean | `@${string}`,
 	steam_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -66843,6 +67009,8 @@ count?: [{	columns?: Array<ResolverInputTypes["abandoned_matches_select_column"]
 	_or?: Array<ResolverInputTypes["abandoned_matches_bool_exp"]> | undefined | null,
 	abandoned_at?: ResolverInputTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null,
+	match?: ResolverInputTypes["matches_bool_exp"] | undefined | null,
+	match_id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null,
 	steam_id?: ResolverInputTypes["bigint_comparison_exp"] | undefined | null
 };
 	/** unique or primary key constraints on table "abandoned_matches" */
@@ -66855,12 +67023,15 @@ count?: [{	columns?: Array<ResolverInputTypes["abandoned_matches_select_column"]
 ["abandoned_matches_insert_input"]: {
 	abandoned_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
+	match?: ResolverInputTypes["matches_obj_rel_insert_input"] | undefined | null,
+	match_id?: ResolverInputTypes["uuid"] | undefined | null,
 	steam_id?: ResolverInputTypes["bigint"] | undefined | null
 };
 	/** aggregate max on columns */
 ["abandoned_matches_max_fields"]: AliasType<{
 	abandoned_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
+	match_id?:boolean | `@${string}`,
 	steam_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -66868,12 +67039,14 @@ count?: [{	columns?: Array<ResolverInputTypes["abandoned_matches_select_column"]
 ["abandoned_matches_max_order_by"]: {
 	abandoned_at?: ResolverInputTypes["order_by"] | undefined | null,
 	id?: ResolverInputTypes["order_by"] | undefined | null,
+	match_id?: ResolverInputTypes["order_by"] | undefined | null,
 	steam_id?: ResolverInputTypes["order_by"] | undefined | null
 };
 	/** aggregate min on columns */
 ["abandoned_matches_min_fields"]: AliasType<{
 	abandoned_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
+	match_id?:boolean | `@${string}`,
 	steam_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -66881,6 +67054,7 @@ count?: [{	columns?: Array<ResolverInputTypes["abandoned_matches_select_column"]
 ["abandoned_matches_min_order_by"]: {
 	abandoned_at?: ResolverInputTypes["order_by"] | undefined | null,
 	id?: ResolverInputTypes["order_by"] | undefined | null,
+	match_id?: ResolverInputTypes["order_by"] | undefined | null,
 	steam_id?: ResolverInputTypes["order_by"] | undefined | null
 };
 	/** response of any mutation on the table "abandoned_matches" */
@@ -66901,6 +67075,8 @@ count?: [{	columns?: Array<ResolverInputTypes["abandoned_matches_select_column"]
 ["abandoned_matches_order_by"]: {
 	abandoned_at?: ResolverInputTypes["order_by"] | undefined | null,
 	id?: ResolverInputTypes["order_by"] | undefined | null,
+	match?: ResolverInputTypes["matches_order_by"] | undefined | null,
+	match_id?: ResolverInputTypes["order_by"] | undefined | null,
 	steam_id?: ResolverInputTypes["order_by"] | undefined | null
 };
 	/** primary key columns input for table: abandoned_matches */
@@ -66913,6 +67089,7 @@ count?: [{	columns?: Array<ResolverInputTypes["abandoned_matches_select_column"]
 ["abandoned_matches_set_input"]: {
 	abandoned_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
+	match_id?: ResolverInputTypes["uuid"] | undefined | null,
 	steam_id?: ResolverInputTypes["bigint"] | undefined | null
 };
 	/** aggregate stddev on columns */
@@ -66953,6 +67130,7 @@ count?: [{	columns?: Array<ResolverInputTypes["abandoned_matches_select_column"]
 ["abandoned_matches_stream_cursor_value_input"]: {
 	abandoned_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
+	match_id?: ResolverInputTypes["uuid"] | undefined | null,
 	steam_id?: ResolverInputTypes["bigint"] | undefined | null
 };
 	/** aggregate sum on columns */
@@ -78721,6 +78899,7 @@ count?: [{	columns?: Array<ResolverInputTypes["gamedata_signature_validations_se
 	_match_type?: string | undefined | null,
 	_role?: string | undefined | null,
 	_season_id?: ResolverInputTypes["uuid"] | undefined | null,
+	_source?: string | undefined | null,
 	_window_days?: number | undefined | null
 };
 	["get_league_season_leaderboard_args"]: {
@@ -78734,6 +78913,7 @@ count?: [{	columns?: Array<ResolverInputTypes["gamedata_signature_validations_se
 	_match_type?: string | undefined | null,
 	_player_steam_id?: string | undefined | null,
 	_season_id?: ResolverInputTypes["uuid"] | undefined | null,
+	_source?: string | undefined | null,
 	_window_days?: number | undefined | null
 };
 	["inet"]:unknown;
@@ -78794,6 +78974,7 @@ count?: [{	columns?: Array<ResolverInputTypes["gamedata_signature_validations_se
 	matches_played?:boolean | `@${string}`,
 	player_avatar_url?:boolean | `@${string}`,
 	player_country?:boolean | `@${string}`,
+	player_custom_avatar_url?:boolean | `@${string}`,
 	player_name?:boolean | `@${string}`,
 	player_steam_id?:boolean | `@${string}`,
 	secondary_value?:boolean | `@${string}`,
@@ -78837,6 +79018,7 @@ count?: [{	columns?: Array<ResolverInputTypes["leaderboard_entries_select_column
 	matches_played?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	player_avatar_url?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
 	player_country?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
+	player_custom_avatar_url?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
 	player_name?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
 	player_steam_id?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
 	secondary_value?: ResolverInputTypes["float8_comparison_exp"] | undefined | null,
@@ -78855,6 +79037,7 @@ count?: [{	columns?: Array<ResolverInputTypes["leaderboard_entries_select_column
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: ResolverInputTypes["float8"] | undefined | null,
@@ -78866,6 +79049,7 @@ count?: [{	columns?: Array<ResolverInputTypes["leaderboard_entries_select_column
 	matches_played?:boolean | `@${string}`,
 	player_avatar_url?:boolean | `@${string}`,
 	player_country?:boolean | `@${string}`,
+	player_custom_avatar_url?:boolean | `@${string}`,
 	player_name?:boolean | `@${string}`,
 	player_steam_id?:boolean | `@${string}`,
 	secondary_value?:boolean | `@${string}`,
@@ -78878,6 +79062,7 @@ count?: [{	columns?: Array<ResolverInputTypes["leaderboard_entries_select_column
 	matches_played?:boolean | `@${string}`,
 	player_avatar_url?:boolean | `@${string}`,
 	player_country?:boolean | `@${string}`,
+	player_custom_avatar_url?:boolean | `@${string}`,
 	player_name?:boolean | `@${string}`,
 	player_steam_id?:boolean | `@${string}`,
 	secondary_value?:boolean | `@${string}`,
@@ -78898,6 +79083,7 @@ count?: [{	columns?: Array<ResolverInputTypes["leaderboard_entries_select_column
 	matches_played?: ResolverInputTypes["order_by"] | undefined | null,
 	player_avatar_url?: ResolverInputTypes["order_by"] | undefined | null,
 	player_country?: ResolverInputTypes["order_by"] | undefined | null,
+	player_custom_avatar_url?: ResolverInputTypes["order_by"] | undefined | null,
 	player_name?: ResolverInputTypes["order_by"] | undefined | null,
 	player_steam_id?: ResolverInputTypes["order_by"] | undefined | null,
 	secondary_value?: ResolverInputTypes["order_by"] | undefined | null,
@@ -78911,6 +79097,7 @@ count?: [{	columns?: Array<ResolverInputTypes["leaderboard_entries_select_column
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: ResolverInputTypes["float8"] | undefined | null,
@@ -78953,6 +79140,7 @@ count?: [{	columns?: Array<ResolverInputTypes["leaderboard_entries_select_column
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: ResolverInputTypes["float8"] | undefined | null,
@@ -83868,6 +84056,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_demo_sessions_select_column
 	checked_in?:boolean | `@${string}`,
 	discord_id?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
+	is_connected?:boolean | `@${string}`,
 	/** An object relationship */
 	lineup?:ResolverInputTypes["match_lineups"],
 	match_lineup_id?:boolean | `@${string}`,
@@ -83961,6 +84150,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_lineup_players_select_colum
 	checked_in?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	discord_id?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
 	id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null,
+	is_connected?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	lineup?: ResolverInputTypes["match_lineups_bool_exp"] | undefined | null,
 	match_lineup_id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null,
 	party_id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null,
@@ -83981,6 +84171,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_lineup_players_select_colum
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	lineup?: ResolverInputTypes["match_lineups_obj_rel_insert_input"] | undefined | null,
 	match_lineup_id?: ResolverInputTypes["uuid"] | undefined | null,
 	party_id?: ResolverInputTypes["uuid"] | undefined | null,
@@ -84047,6 +84238,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_lineup_players_select_colum
 	checked_in?: ResolverInputTypes["order_by"] | undefined | null,
 	discord_id?: ResolverInputTypes["order_by"] | undefined | null,
 	id?: ResolverInputTypes["order_by"] | undefined | null,
+	is_connected?: ResolverInputTypes["order_by"] | undefined | null,
 	lineup?: ResolverInputTypes["match_lineups_order_by"] | undefined | null,
 	match_lineup_id?: ResolverInputTypes["order_by"] | undefined | null,
 	party_id?: ResolverInputTypes["order_by"] | undefined | null,
@@ -84071,6 +84263,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_lineup_players_select_colum
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	match_lineup_id?: ResolverInputTypes["uuid"] | undefined | null,
 	party_id?: ResolverInputTypes["uuid"] | undefined | null,
 	party_source?: ResolverInputTypes["e_match_party_sources_enum"] | undefined | null,
@@ -84117,6 +84310,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_lineup_players_select_colum
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	match_lineup_id?: ResolverInputTypes["uuid"] | undefined | null,
 	party_id?: ResolverInputTypes["uuid"] | undefined | null,
 	party_source?: ResolverInputTypes["e_match_party_sources_enum"] | undefined | null,
@@ -85611,6 +85805,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_map_rounds_select_column"]>
 };
 	/** columns and relationships of "match_map_veto_picks" */
 ["match_map_veto_picks"]: AliasType<{
+	auto_picked?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
 	/** An object relationship */
@@ -85633,7 +85828,21 @@ count?: [{	columns?: Array<ResolverInputTypes["match_map_rounds_select_column"]>
 		__typename?: boolean | `@${string}`
 }>;
 	["match_map_veto_picks_aggregate_bool_exp"]: {
+	bool_and?: ResolverInputTypes["match_map_veto_picks_aggregate_bool_exp_bool_and"] | undefined | null,
+	bool_or?: ResolverInputTypes["match_map_veto_picks_aggregate_bool_exp_bool_or"] | undefined | null,
 	count?: ResolverInputTypes["match_map_veto_picks_aggregate_bool_exp_count"] | undefined | null
+};
+	["match_map_veto_picks_aggregate_bool_exp_bool_and"]: {
+	arguments: ResolverInputTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: ResolverInputTypes["match_map_veto_picks_bool_exp"] | undefined | null,
+	predicate: ResolverInputTypes["Boolean_comparison_exp"]
+};
+	["match_map_veto_picks_aggregate_bool_exp_bool_or"]: {
+	arguments: ResolverInputTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: ResolverInputTypes["match_map_veto_picks_bool_exp"] | undefined | null,
+	predicate: ResolverInputTypes["Boolean_comparison_exp"]
 };
 	["match_map_veto_picks_aggregate_bool_exp_count"]: {
 	arguments?: Array<ResolverInputTypes["match_map_veto_picks_select_column"]> | undefined | null,
@@ -85665,6 +85874,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_map_veto_picks_select_colum
 	_and?: Array<ResolverInputTypes["match_map_veto_picks_bool_exp"]> | undefined | null,
 	_not?: ResolverInputTypes["match_map_veto_picks_bool_exp"] | undefined | null,
 	_or?: Array<ResolverInputTypes["match_map_veto_picks_bool_exp"]> | undefined | null,
+	auto_picked?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null,
 	map?: ResolverInputTypes["maps_bool_exp"] | undefined | null,
@@ -85680,6 +85890,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_map_veto_picks_select_colum
 ["match_map_veto_picks_constraint"]:match_map_veto_picks_constraint;
 	/** input type for inserting data into table "match_map_veto_picks" */
 ["match_map_veto_picks_insert_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
 	map?: ResolverInputTypes["maps_obj_rel_insert_input"] | undefined | null,
@@ -85745,6 +85956,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_map_veto_picks_select_colum
 };
 	/** Ordering options when selecting data from "match_map_veto_picks". */
 ["match_map_veto_picks_order_by"]: {
+	auto_picked?: ResolverInputTypes["order_by"] | undefined | null,
 	created_at?: ResolverInputTypes["order_by"] | undefined | null,
 	id?: ResolverInputTypes["order_by"] | undefined | null,
 	map?: ResolverInputTypes["maps_order_by"] | undefined | null,
@@ -85762,8 +85974,13 @@ count?: [{	columns?: Array<ResolverInputTypes["match_map_veto_picks_select_colum
 };
 	/** select columns of table "match_map_veto_picks" */
 ["match_map_veto_picks_select_column"]:match_map_veto_picks_select_column;
+	/** select "match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_map_veto_picks" */
+["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]:match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns;
+	/** select "match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_map_veto_picks" */
+["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]:match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns;
 	/** input type for updating data in table "match_map_veto_picks" */
 ["match_map_veto_picks_set_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
 	map_id?: ResolverInputTypes["uuid"] | undefined | null,
@@ -85781,6 +85998,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_map_veto_picks_select_colum
 };
 	/** Initial value of the column from where the streaming should start */
 ["match_map_veto_picks_stream_cursor_value_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
 	map_id?: ResolverInputTypes["uuid"] | undefined | null,
@@ -85801,6 +86019,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_map_veto_picks_select_colum
 ["match_maps"]: AliasType<{
 	clips_count?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
+	demo_processing_started_at?:boolean | `@${string}`,
 demos?: [{	/** distinct select on columns */
 	distinct_on?: Array<ResolverInputTypes["match_map_demos_select_column"]> | undefined | null,	/** limit the number of rows returned */
 	limit?: number | undefined | null,	/** skip the first n rows. Use only with order_by */
@@ -86046,6 +86265,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 	_or?: Array<ResolverInputTypes["match_maps_bool_exp"]> | undefined | null,
 	clips_count?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz_comparison_exp"] | undefined | null,
+	demo_processing_started_at?: ResolverInputTypes["timestamptz_comparison_exp"] | undefined | null,
 	demos?: ResolverInputTypes["match_map_demos_bool_exp"] | undefined | null,
 	demos_aggregate?: ResolverInputTypes["match_map_demos_aggregate_bool_exp"] | undefined | null,
 	demos_download_url?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
@@ -86106,6 +86326,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 ["match_maps_insert_input"]: {
 	clips_count?: number | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	demos?: ResolverInputTypes["match_map_demos_arr_rel_insert_input"] | undefined | null,
 	e_match_map_status?: ResolverInputTypes["e_match_map_status_obj_rel_insert_input"] | undefined | null,
 	ended_at?: ResolverInputTypes["timestamptz"] | undefined | null,
@@ -86140,6 +86361,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 ["match_maps_max_fields"]: AliasType<{
 	clips_count?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
+	demo_processing_started_at?:boolean | `@${string}`,
 	/** A computed field, executes function "match_map_demo_download_url" */
 	demos_download_url?:boolean | `@${string}`,
 	/** A computed field, executes function "match_map_demo_total_size" */
@@ -86166,6 +86388,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 ["match_maps_max_order_by"]: {
 	clips_count?: ResolverInputTypes["order_by"] | undefined | null,
 	created_at?: ResolverInputTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: ResolverInputTypes["order_by"] | undefined | null,
 	ended_at?: ResolverInputTypes["order_by"] | undefined | null,
 	id?: ResolverInputTypes["order_by"] | undefined | null,
 	latest_clip_at?: ResolverInputTypes["order_by"] | undefined | null,
@@ -86183,6 +86406,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 ["match_maps_min_fields"]: AliasType<{
 	clips_count?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
+	demo_processing_started_at?:boolean | `@${string}`,
 	/** A computed field, executes function "match_map_demo_download_url" */
 	demos_download_url?:boolean | `@${string}`,
 	/** A computed field, executes function "match_map_demo_total_size" */
@@ -86209,6 +86433,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 ["match_maps_min_order_by"]: {
 	clips_count?: ResolverInputTypes["order_by"] | undefined | null,
 	created_at?: ResolverInputTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: ResolverInputTypes["order_by"] | undefined | null,
 	ended_at?: ResolverInputTypes["order_by"] | undefined | null,
 	id?: ResolverInputTypes["order_by"] | undefined | null,
 	latest_clip_at?: ResolverInputTypes["order_by"] | undefined | null,
@@ -86246,6 +86471,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 ["match_maps_order_by"]: {
 	clips_count?: ResolverInputTypes["order_by"] | undefined | null,
 	created_at?: ResolverInputTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: ResolverInputTypes["order_by"] | undefined | null,
 	demos_aggregate?: ResolverInputTypes["match_map_demos_aggregate_order_by"] | undefined | null,
 	demos_download_url?: ResolverInputTypes["order_by"] | undefined | null,
 	demos_total_size?: ResolverInputTypes["order_by"] | undefined | null,
@@ -86291,6 +86517,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 ["match_maps_set_input"]: {
 	clips_count?: number | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	ended_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
 	latest_clip_at?: ResolverInputTypes["timestamptz"] | undefined | null,
@@ -86387,6 +86614,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_maps_select_column"]> | und
 ["match_maps_stream_cursor_value_input"]: {
 	clips_count?: number | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	ended_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
 	latest_clip_at?: ResolverInputTypes["timestamptz"] | undefined | null,
@@ -86555,6 +86783,7 @@ matches_aggregate?: [{	/** distinct select on columns */
 	tournament_stage?:ResolverInputTypes["tournament_stages"],
 	tv_delay?:boolean | `@${string}`,
 	type?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregated selection of "match_options" */
@@ -86587,6 +86816,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** Boolean expression to filter rows from the table "match_options". All fields are combined with a logical 'AND'. */
@@ -86626,7 +86856,8 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	tournament_bracket?: ResolverInputTypes["tournament_brackets_bool_exp"] | undefined | null,
 	tournament_stage?: ResolverInputTypes["tournament_stages_bool_exp"] | undefined | null,
 	tv_delay?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
-	type?: ResolverInputTypes["e_match_types_enum_comparison_exp"] | undefined | null
+	type?: ResolverInputTypes["e_match_types_enum_comparison_exp"] | undefined | null,
+	veto_pick_timeout?: ResolverInputTypes["Int_comparison_exp"] | undefined | null
 };
 	/** unique or primary key constraints on table "match_options" */
 ["match_options_constraint"]:match_options_constraint;
@@ -86638,7 +86869,8 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** input type for inserting data into table "match_options" */
 ["match_options_insert_input"]: {
@@ -86672,7 +86904,8 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	tournament_bracket?: ResolverInputTypes["tournament_brackets_obj_rel_insert_input"] | undefined | null,
 	tournament_stage?: ResolverInputTypes["tournament_stages_obj_rel_insert_input"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: ResolverInputTypes["e_match_types_enum"] | undefined | null
+	type?: ResolverInputTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate max on columns */
 ["match_options_max_fields"]: AliasType<{
@@ -86687,6 +86920,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	regions?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate min on columns */
@@ -86702,6 +86936,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	regions?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** response of any mutation on the table "match_options" */
@@ -86757,7 +86992,8 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	tournament_bracket?: ResolverInputTypes["tournament_brackets_order_by"] | undefined | null,
 	tournament_stage?: ResolverInputTypes["tournament_stages_order_by"] | undefined | null,
 	tv_delay?: ResolverInputTypes["order_by"] | undefined | null,
-	type?: ResolverInputTypes["order_by"] | undefined | null
+	type?: ResolverInputTypes["order_by"] | undefined | null,
+	veto_pick_timeout?: ResolverInputTypes["order_by"] | undefined | null
 };
 	/** primary key columns input for table: match_options */
 ["match_options_pk_columns_input"]: {
@@ -86792,7 +87028,8 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	tech_timeout_setting?: ResolverInputTypes["e_timeout_settings_enum"] | undefined | null,
 	timeout_setting?: ResolverInputTypes["e_timeout_settings_enum"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: ResolverInputTypes["e_match_types_enum"] | undefined | null
+	type?: ResolverInputTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate stddev on columns */
 ["match_options_stddev_fields"]: AliasType<{
@@ -86803,6 +87040,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate stddev_pop on columns */
@@ -86814,6 +87052,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate stddev_samp on columns */
@@ -86825,6 +87064,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** Streaming cursor of the table "match_options" */
@@ -86861,7 +87101,8 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	tech_timeout_setting?: ResolverInputTypes["e_timeout_settings_enum"] | undefined | null,
 	timeout_setting?: ResolverInputTypes["e_timeout_settings_enum"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: ResolverInputTypes["e_match_types_enum"] | undefined | null
+	type?: ResolverInputTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate sum on columns */
 ["match_options_sum_fields"]: AliasType<{
@@ -86872,6 +87113,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** update columns of table "match_options" */
@@ -86893,6 +87135,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate var_samp on columns */
@@ -86904,6 +87147,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** aggregate variance on columns */
@@ -86915,10 +87159,12 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 	number_of_substitutes?:boolean | `@${string}`,
 	round_restart_delay?:boolean | `@${string}`,
 	tv_delay?:boolean | `@${string}`,
+	veto_pick_timeout?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
 	/** columns and relationships of "match_region_veto_picks" */
 ["match_region_veto_picks"]: AliasType<{
+	auto_picked?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
 	/** An object relationship */
@@ -86938,7 +87184,21 @@ count?: [{	columns?: Array<ResolverInputTypes["match_options_select_column"]> | 
 		__typename?: boolean | `@${string}`
 }>;
 	["match_region_veto_picks_aggregate_bool_exp"]: {
+	bool_and?: ResolverInputTypes["match_region_veto_picks_aggregate_bool_exp_bool_and"] | undefined | null,
+	bool_or?: ResolverInputTypes["match_region_veto_picks_aggregate_bool_exp_bool_or"] | undefined | null,
 	count?: ResolverInputTypes["match_region_veto_picks_aggregate_bool_exp_count"] | undefined | null
+};
+	["match_region_veto_picks_aggregate_bool_exp_bool_and"]: {
+	arguments: ResolverInputTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: ResolverInputTypes["match_region_veto_picks_bool_exp"] | undefined | null,
+	predicate: ResolverInputTypes["Boolean_comparison_exp"]
+};
+	["match_region_veto_picks_aggregate_bool_exp_bool_or"]: {
+	arguments: ResolverInputTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: ResolverInputTypes["match_region_veto_picks_bool_exp"] | undefined | null,
+	predicate: ResolverInputTypes["Boolean_comparison_exp"]
 };
 	["match_region_veto_picks_aggregate_bool_exp_count"]: {
 	arguments?: Array<ResolverInputTypes["match_region_veto_picks_select_column"]> | undefined | null,
@@ -86970,6 +87230,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_region_veto_picks_select_co
 	_and?: Array<ResolverInputTypes["match_region_veto_picks_bool_exp"]> | undefined | null,
 	_not?: ResolverInputTypes["match_region_veto_picks_bool_exp"] | undefined | null,
 	_or?: Array<ResolverInputTypes["match_region_veto_picks_bool_exp"]> | undefined | null,
+	auto_picked?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null,
 	match?: ResolverInputTypes["matches_bool_exp"] | undefined | null,
@@ -86983,6 +87244,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_region_veto_picks_select_co
 ["match_region_veto_picks_constraint"]:match_region_veto_picks_constraint;
 	/** input type for inserting data into table "match_region_veto_picks" */
 ["match_region_veto_picks_insert_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
 	match?: ResolverInputTypes["matches_obj_rel_insert_input"] | undefined | null,
@@ -87042,6 +87304,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_region_veto_picks_select_co
 };
 	/** Ordering options when selecting data from "match_region_veto_picks". */
 ["match_region_veto_picks_order_by"]: {
+	auto_picked?: ResolverInputTypes["order_by"] | undefined | null,
 	created_at?: ResolverInputTypes["order_by"] | undefined | null,
 	id?: ResolverInputTypes["order_by"] | undefined | null,
 	match?: ResolverInputTypes["matches_order_by"] | undefined | null,
@@ -87057,8 +87320,13 @@ count?: [{	columns?: Array<ResolverInputTypes["match_region_veto_picks_select_co
 };
 	/** select columns of table "match_region_veto_picks" */
 ["match_region_veto_picks_select_column"]:match_region_veto_picks_select_column;
+	/** select "match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_region_veto_picks" */
+["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]:match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns;
+	/** select "match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_region_veto_picks" */
+["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]:match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns;
 	/** input type for updating data in table "match_region_veto_picks" */
 ["match_region_veto_picks_set_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
 	match_id?: ResolverInputTypes["uuid"] | undefined | null,
@@ -87075,6 +87343,7 @@ count?: [{	columns?: Array<ResolverInputTypes["match_region_veto_picks_select_co
 };
 	/** Initial value of the column from where the streaming should start */
 ["match_region_veto_picks_stream_cursor_value_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	id?: ResolverInputTypes["uuid"] | undefined | null,
 	match_id?: ResolverInputTypes["uuid"] | undefined | null,
@@ -87896,6 +88165,7 @@ tournament_brackets_aggregate?: [{	/** distinct select on columns */
 	where?: ResolverInputTypes["tournament_brackets_bool_exp"] | undefined | null},ResolverInputTypes["tournament_brackets_aggregate"]],
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?:boolean | `@${string}`,
+	veto_pick_expires_at?:boolean | `@${string}`,
 	/** An object relationship */
 	winner?:ResolverInputTypes["match_lineups"],
 	winning_lineup_id?:boolean | `@${string}`,
@@ -88062,6 +88332,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	tournament_brackets?: ResolverInputTypes["tournament_brackets_bool_exp"] | undefined | null,
 	tournament_brackets_aggregate?: ResolverInputTypes["tournament_brackets_aggregate_bool_exp"] | undefined | null,
 	tv_connection_string?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
+	veto_pick_expires_at?: ResolverInputTypes["timestamptz_comparison_exp"] | undefined | null,
 	winner?: ResolverInputTypes["match_lineups_bool_exp"] | undefined | null,
 	winning_lineup_id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null
 };
@@ -88116,6 +88387,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	status?: ResolverInputTypes["e_match_status_enum"] | undefined | null,
 	streams?: ResolverInputTypes["match_streams_arr_rel_insert_input"] | undefined | null,
 	tournament_brackets?: ResolverInputTypes["tournament_brackets_arr_rel_insert_input"] | undefined | null,
+	veto_pick_expires_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	winner?: ResolverInputTypes["match_lineups_obj_rel_insert_input"] | undefined | null,
 	winning_lineup_id?: ResolverInputTypes["uuid"] | undefined | null
 };
@@ -88166,6 +88438,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	started_at?:boolean | `@${string}`,
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?:boolean | `@${string}`,
+	veto_pick_expires_at?:boolean | `@${string}`,
 	winning_lineup_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -88190,6 +88463,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	share_code?: ResolverInputTypes["order_by"] | undefined | null,
 	source?: ResolverInputTypes["order_by"] | undefined | null,
 	started_at?: ResolverInputTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: ResolverInputTypes["order_by"] | undefined | null,
 	winning_lineup_id?: ResolverInputTypes["order_by"] | undefined | null
 };
 	/** aggregate min on columns */
@@ -88239,6 +88513,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	started_at?:boolean | `@${string}`,
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?:boolean | `@${string}`,
+	veto_pick_expires_at?:boolean | `@${string}`,
 	winning_lineup_id?:boolean | `@${string}`,
 		__typename?: boolean | `@${string}`
 }>;
@@ -88263,6 +88538,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	share_code?: ResolverInputTypes["order_by"] | undefined | null,
 	source?: ResolverInputTypes["order_by"] | undefined | null,
 	started_at?: ResolverInputTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: ResolverInputTypes["order_by"] | undefined | null,
 	winning_lineup_id?: ResolverInputTypes["order_by"] | undefined | null
 };
 	/** response of any mutation on the table "matches" */
@@ -88363,6 +88639,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	teams_aggregate?: ResolverInputTypes["teams_aggregate_order_by"] | undefined | null,
 	tournament_brackets_aggregate?: ResolverInputTypes["tournament_brackets_aggregate_order_by"] | undefined | null,
 	tv_connection_string?: ResolverInputTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: ResolverInputTypes["order_by"] | undefined | null,
 	winner?: ResolverInputTypes["match_lineups_order_by"] | undefined | null,
 	winning_lineup_id?: ResolverInputTypes["order_by"] | undefined | null
 };
@@ -88393,6 +88670,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	source?: string | undefined | null,
 	started_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	status?: ResolverInputTypes["e_match_status_enum"] | undefined | null,
+	veto_pick_expires_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: ResolverInputTypes["uuid"] | undefined | null
 };
 	/** aggregate stddev on columns */
@@ -88463,6 +88741,7 @@ count?: [{	columns?: Array<ResolverInputTypes["matches_select_column"]> | undefi
 	source?: string | undefined | null,
 	started_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	status?: ResolverInputTypes["e_match_status_enum"] | undefined | null,
+	veto_pick_expires_at?: ResolverInputTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: ResolverInputTypes["uuid"] | undefined | null
 };
 	/** aggregate sum on columns */
@@ -89152,6 +89431,7 @@ delete_v_team_stage_results?: [{	/** filter the rows which have to be deleted */
 	where: ResolverInputTypes["v_team_stage_results_bool_exp"]},ResolverInputTypes["v_team_stage_results_mutation_response"]],
 delete_v_team_stage_results_by_pk?: [{	tournament_stage_id: ResolverInputTypes["uuid"],	tournament_team_id: ResolverInputTypes["uuid"]},ResolverInputTypes["v_team_stage_results"]],
 denyInvite?: [{	invite_id: ResolverInputTypes["uuid"],	type: string},ResolverInputTypes["SuccessOutput"]],
+denyNameChange?: [{	name: string,	steam_id: ResolverInputTypes["bigint"]},ResolverInputTypes["SuccessOutput"]],
 forfeitMatch?: [{	match_id: ResolverInputTypes["uuid"],	winning_lineup_id: ResolverInputTypes["uuid"]},ResolverInputTypes["SuccessOutput"]],
 getLiveStreamSpecState?: [{	match_id: ResolverInputTypes["uuid"]},ResolverInputTypes["LiveStreamSpecState"]],
 	getTestUploadLink?:ResolverInputTypes["GetTestUploadResponse"],
@@ -105426,6 +105706,8 @@ awards_aggregate?: [{	/** distinct select on columns */
 	offset?: number | undefined | null,	/** sort the rows by one or more columns */
 	order_by?: Array<ResolverInputTypes["award_recipients_order_by"]> | undefined | null,	/** filter the rows returned */
 	where?: ResolverInputTypes["award_recipients_bool_exp"] | undefined | null},ResolverInputTypes["award_recipients_aggregate"]],
+	/** A computed field, executes function "banned_until" */
+	banned_until?:boolean | `@${string}`,
 coach_lineups?: [{	/** distinct select on columns */
 	distinct_on?: Array<ResolverInputTypes["match_lineups_select_column"]> | undefined | null,	/** limit the number of rows returned */
 	limit?: number | undefined | null,	/** skip the first n rows. Use only with order_by */
@@ -105574,6 +105856,8 @@ invited_players_aggregate?: [{	/** distinct select on columns */
 	offset?: number | undefined | null,	/** sort the rows by one or more columns */
 	order_by?: Array<ResolverInputTypes["team_invites_order_by"]> | undefined | null,	/** filter the rows returned */
 	where?: ResolverInputTypes["team_invites_bool_exp"] | undefined | null},ResolverInputTypes["team_invites_aggregate"]],
+	/** A computed field, executes function "is_admin_sanctioned" */
+	is_admin_sanctioned?:boolean | `@${string}`,
 	/** A computed field, executes function "is_banned" */
 	is_banned?:boolean | `@${string}`,
 	/** A computed field, executes function "is_gagged" */
@@ -105586,6 +105870,8 @@ invited_players_aggregate?: [{	/** distinct select on columns */
 	is_in_lobby?:boolean | `@${string}`,
 	/** A computed field, executes function "is_muted" */
 	is_muted?:boolean | `@${string}`,
+	/** A computed field, executes function "is_registered" */
+	is_registered?:boolean | `@${string}`,
 kills?: [{	/** distinct select on columns */
 	distinct_on?: Array<ResolverInputTypes["player_kills_select_column"]> | undefined | null,	/** limit the number of rows returned */
 	limit?: number | undefined | null,	/** skip the first n rows. Use only with order_by */
@@ -105981,6 +106267,7 @@ count?: [{	columns?: Array<ResolverInputTypes["players_select_column"]> | undefi
 	avatar_url?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
 	awards?: ResolverInputTypes["award_recipients_bool_exp"] | undefined | null,
 	awards_aggregate?: ResolverInputTypes["award_recipients_aggregate_bool_exp"] | undefined | null,
+	banned_until?: ResolverInputTypes["timestamptz_comparison_exp"] | undefined | null,
 	coach_lineups?: ResolverInputTypes["match_lineups_bool_exp"] | undefined | null,
 	coach_lineups_aggregate?: ResolverInputTypes["match_lineups_aggregate_bool_exp"] | undefined | null,
 	country?: ResolverInputTypes["String_comparison_exp"] | undefined | null,
@@ -106017,12 +106304,14 @@ count?: [{	columns?: Array<ResolverInputTypes["players_select_column"]> | undefi
 	game_ban_count?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	invited_players?: ResolverInputTypes["team_invites_bool_exp"] | undefined | null,
 	invited_players_aggregate?: ResolverInputTypes["team_invites_aggregate_bool_exp"] | undefined | null,
+	is_admin_sanctioned?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	is_banned?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	is_gagged?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_another_match?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_draft?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_lobby?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	is_muted?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
+	is_registered?: ResolverInputTypes["Boolean_comparison_exp"] | undefined | null,
 	kills?: ResolverInputTypes["player_kills_bool_exp"] | undefined | null,
 	kills_aggregate?: ResolverInputTypes["player_kills_aggregate_bool_exp"] | undefined | null,
 	kills_by_weapons?: ResolverInputTypes["player_kills_by_weapon_bool_exp"] | undefined | null,
@@ -106185,6 +106474,8 @@ count?: [{	columns?: Array<ResolverInputTypes["players_select_column"]> | undefi
 	/** aggregate max on columns */
 ["players_max_fields"]: AliasType<{
 	avatar_url?:boolean | `@${string}`,
+	/** A computed field, executes function "banned_until" */
+	banned_until?:boolean | `@${string}`,
 	country?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
 	/** A computed field, executes function "get_player_current_lobby_id" */
@@ -106235,6 +106526,8 @@ count?: [{	columns?: Array<ResolverInputTypes["players_select_column"]> | undefi
 	/** aggregate min on columns */
 ["players_min_fields"]: AliasType<{
 	avatar_url?:boolean | `@${string}`,
+	/** A computed field, executes function "banned_until" */
+	banned_until?:boolean | `@${string}`,
 	country?:boolean | `@${string}`,
 	created_at?:boolean | `@${string}`,
 	/** A computed field, executes function "get_player_current_lobby_id" */
@@ -106310,6 +106603,7 @@ count?: [{	columns?: Array<ResolverInputTypes["players_select_column"]> | undefi
 	assited_by_players_aggregate?: ResolverInputTypes["player_assists_aggregate_order_by"] | undefined | null,
 	avatar_url?: ResolverInputTypes["order_by"] | undefined | null,
 	awards_aggregate?: ResolverInputTypes["award_recipients_aggregate_order_by"] | undefined | null,
+	banned_until?: ResolverInputTypes["order_by"] | undefined | null,
 	coach_lineups_aggregate?: ResolverInputTypes["match_lineups_aggregate_order_by"] | undefined | null,
 	country?: ResolverInputTypes["order_by"] | undefined | null,
 	created_at?: ResolverInputTypes["order_by"] | undefined | null,
@@ -106335,12 +106629,14 @@ count?: [{	columns?: Array<ResolverInputTypes["players_select_column"]> | undefi
 	friends_aggregate?: ResolverInputTypes["my_friends_aggregate_order_by"] | undefined | null,
 	game_ban_count?: ResolverInputTypes["order_by"] | undefined | null,
 	invited_players_aggregate?: ResolverInputTypes["team_invites_aggregate_order_by"] | undefined | null,
+	is_admin_sanctioned?: ResolverInputTypes["order_by"] | undefined | null,
 	is_banned?: ResolverInputTypes["order_by"] | undefined | null,
 	is_gagged?: ResolverInputTypes["order_by"] | undefined | null,
 	is_in_another_match?: ResolverInputTypes["order_by"] | undefined | null,
 	is_in_draft?: ResolverInputTypes["order_by"] | undefined | null,
 	is_in_lobby?: ResolverInputTypes["order_by"] | undefined | null,
 	is_muted?: ResolverInputTypes["order_by"] | undefined | null,
+	is_registered?: ResolverInputTypes["order_by"] | undefined | null,
 	kills_aggregate?: ResolverInputTypes["player_kills_aggregate_order_by"] | undefined | null,
 	kills_by_weapons_aggregate?: ResolverInputTypes["player_kills_by_weapon_aggregate_order_by"] | undefined | null,
 	language?: ResolverInputTypes["order_by"] | undefined | null,
@@ -128625,10 +128921,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_steam_account_pool_status_selec
 }>;
 	/** columns and relationships of "v_team_ranks" */
 ["v_team_ranks"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128660,10 +128958,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 }>;
 	/** aggregate avg on columns */
 ["v_team_ranks_avg_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128674,10 +128974,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 	_and?: Array<ResolverInputTypes["v_team_ranks_bool_exp"]> | undefined | null,
 	_not?: ResolverInputTypes["v_team_ranks_bool_exp"] | undefined | null,
 	_or?: Array<ResolverInputTypes["v_team_ranks_bool_exp"]> | undefined | null,
+	avg_duel_elo?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	avg_elo?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	avg_faceit_elo?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	avg_faceit_level?: ResolverInputTypes["float8_comparison_exp"] | undefined | null,
 	avg_premier?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
+	avg_wingman_elo?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	max_elo?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	min_elo?: ResolverInputTypes["Int_comparison_exp"] | undefined | null,
 	roster_size?: ResolverInputTypes["bigint_comparison_exp"] | undefined | null,
@@ -128686,10 +128988,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 };
 	/** input type for inserting data into table "v_team_ranks" */
 ["v_team_ranks_insert_input"]: {
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: ResolverInputTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: ResolverInputTypes["bigint"] | undefined | null,
@@ -128698,10 +129002,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 };
 	/** aggregate max on columns */
 ["v_team_ranks_max_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128710,10 +129016,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 }>;
 	/** aggregate min on columns */
 ["v_team_ranks_min_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128726,10 +129034,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 };
 	/** Ordering options when selecting data from "v_team_ranks". */
 ["v_team_ranks_order_by"]: {
+	avg_duel_elo?: ResolverInputTypes["order_by"] | undefined | null,
 	avg_elo?: ResolverInputTypes["order_by"] | undefined | null,
 	avg_faceit_elo?: ResolverInputTypes["order_by"] | undefined | null,
 	avg_faceit_level?: ResolverInputTypes["order_by"] | undefined | null,
 	avg_premier?: ResolverInputTypes["order_by"] | undefined | null,
+	avg_wingman_elo?: ResolverInputTypes["order_by"] | undefined | null,
 	max_elo?: ResolverInputTypes["order_by"] | undefined | null,
 	min_elo?: ResolverInputTypes["order_by"] | undefined | null,
 	roster_size?: ResolverInputTypes["order_by"] | undefined | null,
@@ -128740,10 +129050,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 ["v_team_ranks_select_column"]:v_team_ranks_select_column;
 	/** aggregate stddev on columns */
 ["v_team_ranks_stddev_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128751,10 +129063,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 }>;
 	/** aggregate stddev_pop on columns */
 ["v_team_ranks_stddev_pop_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128762,10 +129076,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 }>;
 	/** aggregate stddev_samp on columns */
 ["v_team_ranks_stddev_samp_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128780,10 +129096,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 };
 	/** Initial value of the column from where the streaming should start */
 ["v_team_ranks_stream_cursor_value_input"]: {
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: ResolverInputTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: ResolverInputTypes["bigint"] | undefined | null,
@@ -128791,10 +129109,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 };
 	/** aggregate sum on columns */
 ["v_team_ranks_sum_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128802,10 +129122,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 }>;
 	/** aggregate var_pop on columns */
 ["v_team_ranks_var_pop_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128813,10 +129135,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 }>;
 	/** aggregate var_samp on columns */
 ["v_team_ranks_var_samp_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -128824,10 +129148,12 @@ count?: [{	columns?: Array<ResolverInputTypes["v_team_ranks_select_column"]> | u
 }>;
 	/** aggregate variance on columns */
 ["v_team_ranks_variance_fields"]: AliasType<{
+	avg_duel_elo?:boolean | `@${string}`,
 	avg_elo?:boolean | `@${string}`,
 	avg_faceit_elo?:boolean | `@${string}`,
 	avg_faceit_level?:boolean | `@${string}`,
 	avg_premier?:boolean | `@${string}`,
+	avg_wingman_elo?:boolean | `@${string}`,
 	max_elo?:boolean | `@${string}`,
 	min_elo?:boolean | `@${string}`,
 	roster_size?:boolean | `@${string}`,
@@ -131605,6 +131931,9 @@ export type ModelTypes = {
 ["abandoned_matches"]: {
 		abandoned_at: ModelTypes["timestamptz"],
 	id: ModelTypes["uuid"],
+	/** An object relationship */
+	match?: ModelTypes["matches"] | undefined | null,
+	match_id?: ModelTypes["uuid"] | undefined | null,
 	steam_id: ModelTypes["bigint"]
 };
 	/** aggregated selection of "abandoned_matches" */
@@ -131670,6 +131999,8 @@ export type ModelTypes = {
 	_or?: Array<ModelTypes["abandoned_matches_bool_exp"]> | undefined | null,
 	abandoned_at?: ModelTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: ModelTypes["uuid_comparison_exp"] | undefined | null,
+	match?: ModelTypes["matches_bool_exp"] | undefined | null,
+	match_id?: ModelTypes["uuid_comparison_exp"] | undefined | null,
 	steam_id?: ModelTypes["bigint_comparison_exp"] | undefined | null
 };
 	["abandoned_matches_constraint"]:abandoned_matches_constraint;
@@ -131681,30 +132012,36 @@ export type ModelTypes = {
 ["abandoned_matches_insert_input"]: {
 	abandoned_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
+	match?: ModelTypes["matches_obj_rel_insert_input"] | undefined | null,
+	match_id?: ModelTypes["uuid"] | undefined | null,
 	steam_id?: ModelTypes["bigint"] | undefined | null
 };
 	/** aggregate max on columns */
 ["abandoned_matches_max_fields"]: {
 		abandoned_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
+	match_id?: ModelTypes["uuid"] | undefined | null,
 	steam_id?: ModelTypes["bigint"] | undefined | null
 };
 	/** order by max() on columns of table "abandoned_matches" */
 ["abandoned_matches_max_order_by"]: {
 	abandoned_at?: ModelTypes["order_by"] | undefined | null,
 	id?: ModelTypes["order_by"] | undefined | null,
+	match_id?: ModelTypes["order_by"] | undefined | null,
 	steam_id?: ModelTypes["order_by"] | undefined | null
 };
 	/** aggregate min on columns */
 ["abandoned_matches_min_fields"]: {
 		abandoned_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
+	match_id?: ModelTypes["uuid"] | undefined | null,
 	steam_id?: ModelTypes["bigint"] | undefined | null
 };
 	/** order by min() on columns of table "abandoned_matches" */
 ["abandoned_matches_min_order_by"]: {
 	abandoned_at?: ModelTypes["order_by"] | undefined | null,
 	id?: ModelTypes["order_by"] | undefined | null,
+	match_id?: ModelTypes["order_by"] | undefined | null,
 	steam_id?: ModelTypes["order_by"] | undefined | null
 };
 	/** response of any mutation on the table "abandoned_matches" */
@@ -131724,6 +132061,8 @@ export type ModelTypes = {
 ["abandoned_matches_order_by"]: {
 	abandoned_at?: ModelTypes["order_by"] | undefined | null,
 	id?: ModelTypes["order_by"] | undefined | null,
+	match?: ModelTypes["matches_order_by"] | undefined | null,
+	match_id?: ModelTypes["order_by"] | undefined | null,
 	steam_id?: ModelTypes["order_by"] | undefined | null
 };
 	/** primary key columns input for table: abandoned_matches */
@@ -131735,6 +132074,7 @@ export type ModelTypes = {
 ["abandoned_matches_set_input"]: {
 	abandoned_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
+	match_id?: ModelTypes["uuid"] | undefined | null,
 	steam_id?: ModelTypes["bigint"] | undefined | null
 };
 	/** aggregate stddev on columns */
@@ -131772,6 +132112,7 @@ export type ModelTypes = {
 ["abandoned_matches_stream_cursor_value_input"]: {
 	abandoned_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
+	match_id?: ModelTypes["uuid"] | undefined | null,
 	steam_id?: ModelTypes["bigint"] | undefined | null
 };
 	/** aggregate sum on columns */
@@ -142534,6 +142875,7 @@ export type ModelTypes = {
 	_match_type?: string | undefined | null,
 	_role?: string | undefined | null,
 	_season_id?: ModelTypes["uuid"] | undefined | null,
+	_source?: string | undefined | null,
 	_window_days?: number | undefined | null
 };
 	["get_league_season_leaderboard_args"]: {
@@ -142547,6 +142889,7 @@ export type ModelTypes = {
 	_match_type?: string | undefined | null,
 	_player_steam_id?: string | undefined | null,
 	_season_id?: ModelTypes["uuid"] | undefined | null,
+	_source?: string | undefined | null,
 	_window_days?: number | undefined | null
 };
 	["inet"]:any;
@@ -142607,6 +142950,7 @@ export type ModelTypes = {
 		matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name: string,
 	player_steam_id: string,
 	secondary_value?: ModelTypes["float8"] | undefined | null,
@@ -142646,6 +142990,7 @@ export type ModelTypes = {
 	matches_played?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	player_avatar_url?: ModelTypes["String_comparison_exp"] | undefined | null,
 	player_country?: ModelTypes["String_comparison_exp"] | undefined | null,
+	player_custom_avatar_url?: ModelTypes["String_comparison_exp"] | undefined | null,
 	player_name?: ModelTypes["String_comparison_exp"] | undefined | null,
 	player_steam_id?: ModelTypes["String_comparison_exp"] | undefined | null,
 	secondary_value?: ModelTypes["float8_comparison_exp"] | undefined | null,
@@ -142664,6 +143009,7 @@ export type ModelTypes = {
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: ModelTypes["float8"] | undefined | null,
@@ -142675,6 +143021,7 @@ export type ModelTypes = {
 		matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: ModelTypes["float8"] | undefined | null,
@@ -142686,6 +143033,7 @@ export type ModelTypes = {
 		matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: ModelTypes["float8"] | undefined | null,
@@ -142704,6 +143052,7 @@ export type ModelTypes = {
 	matches_played?: ModelTypes["order_by"] | undefined | null,
 	player_avatar_url?: ModelTypes["order_by"] | undefined | null,
 	player_country?: ModelTypes["order_by"] | undefined | null,
+	player_custom_avatar_url?: ModelTypes["order_by"] | undefined | null,
 	player_name?: ModelTypes["order_by"] | undefined | null,
 	player_steam_id?: ModelTypes["order_by"] | undefined | null,
 	secondary_value?: ModelTypes["order_by"] | undefined | null,
@@ -142716,6 +143065,7 @@ export type ModelTypes = {
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: ModelTypes["float8"] | undefined | null,
@@ -142755,6 +143105,7 @@ export type ModelTypes = {
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: ModelTypes["float8"] | undefined | null,
@@ -147279,6 +147630,7 @@ export type ModelTypes = {
 	checked_in: boolean,
 	discord_id?: string | undefined | null,
 	id: ModelTypes["uuid"],
+	is_connected: boolean,
 	/** An object relationship */
 	lineup: ModelTypes["match_lineups"],
 	match_lineup_id: ModelTypes["uuid"],
@@ -147368,6 +147720,7 @@ export type ModelTypes = {
 	checked_in?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	discord_id?: ModelTypes["String_comparison_exp"] | undefined | null,
 	id?: ModelTypes["uuid_comparison_exp"] | undefined | null,
+	is_connected?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	lineup?: ModelTypes["match_lineups_bool_exp"] | undefined | null,
 	match_lineup_id?: ModelTypes["uuid_comparison_exp"] | undefined | null,
 	party_id?: ModelTypes["uuid_comparison_exp"] | undefined | null,
@@ -147387,6 +147740,7 @@ export type ModelTypes = {
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	lineup?: ModelTypes["match_lineups_obj_rel_insert_input"] | undefined | null,
 	match_lineup_id?: ModelTypes["uuid"] | undefined | null,
 	party_id?: ModelTypes["uuid"] | undefined | null,
@@ -147450,6 +147804,7 @@ export type ModelTypes = {
 	checked_in?: ModelTypes["order_by"] | undefined | null,
 	discord_id?: ModelTypes["order_by"] | undefined | null,
 	id?: ModelTypes["order_by"] | undefined | null,
+	is_connected?: ModelTypes["order_by"] | undefined | null,
 	lineup?: ModelTypes["match_lineups_order_by"] | undefined | null,
 	match_lineup_id?: ModelTypes["order_by"] | undefined | null,
 	party_id?: ModelTypes["order_by"] | undefined | null,
@@ -147471,6 +147826,7 @@ export type ModelTypes = {
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	match_lineup_id?: ModelTypes["uuid"] | undefined | null,
 	party_id?: ModelTypes["uuid"] | undefined | null,
 	party_source?: ModelTypes["e_match_party_sources_enum"] | undefined | null,
@@ -147514,6 +147870,7 @@ export type ModelTypes = {
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	match_lineup_id?: ModelTypes["uuid"] | undefined | null,
 	party_id?: ModelTypes["uuid"] | undefined | null,
 	party_source?: ModelTypes["e_match_party_sources_enum"] | undefined | null,
@@ -148890,7 +149247,8 @@ export type ModelTypes = {
 };
 	/** columns and relationships of "match_map_veto_picks" */
 ["match_map_veto_picks"]: {
-		created_at: ModelTypes["timestamptz"],
+		auto_picked: boolean,
+	created_at: ModelTypes["timestamptz"],
 	id: ModelTypes["uuid"],
 	/** An object relationship */
 	map: ModelTypes["maps"],
@@ -148910,7 +149268,21 @@ export type ModelTypes = {
 	nodes: Array<ModelTypes["match_map_veto_picks"]>
 };
 	["match_map_veto_picks_aggregate_bool_exp"]: {
+	bool_and?: ModelTypes["match_map_veto_picks_aggregate_bool_exp_bool_and"] | undefined | null,
+	bool_or?: ModelTypes["match_map_veto_picks_aggregate_bool_exp_bool_or"] | undefined | null,
 	count?: ModelTypes["match_map_veto_picks_aggregate_bool_exp_count"] | undefined | null
+};
+	["match_map_veto_picks_aggregate_bool_exp_bool_and"]: {
+	arguments: ModelTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: ModelTypes["match_map_veto_picks_bool_exp"] | undefined | null,
+	predicate: ModelTypes["Boolean_comparison_exp"]
+};
+	["match_map_veto_picks_aggregate_bool_exp_bool_or"]: {
+	arguments: ModelTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: ModelTypes["match_map_veto_picks_bool_exp"] | undefined | null,
+	predicate: ModelTypes["Boolean_comparison_exp"]
 };
 	["match_map_veto_picks_aggregate_bool_exp_count"]: {
 	arguments?: Array<ModelTypes["match_map_veto_picks_select_column"]> | undefined | null,
@@ -148941,6 +149313,7 @@ export type ModelTypes = {
 	_and?: Array<ModelTypes["match_map_veto_picks_bool_exp"]> | undefined | null,
 	_not?: ModelTypes["match_map_veto_picks_bool_exp"] | undefined | null,
 	_or?: Array<ModelTypes["match_map_veto_picks_bool_exp"]> | undefined | null,
+	auto_picked?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	created_at?: ModelTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: ModelTypes["uuid_comparison_exp"] | undefined | null,
 	map?: ModelTypes["maps_bool_exp"] | undefined | null,
@@ -148955,6 +149328,7 @@ export type ModelTypes = {
 	["match_map_veto_picks_constraint"]:match_map_veto_picks_constraint;
 	/** input type for inserting data into table "match_map_veto_picks" */
 ["match_map_veto_picks_insert_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
 	map?: ModelTypes["maps_obj_rel_insert_input"] | undefined | null,
@@ -149017,6 +149391,7 @@ export type ModelTypes = {
 };
 	/** Ordering options when selecting data from "match_map_veto_picks". */
 ["match_map_veto_picks_order_by"]: {
+	auto_picked?: ModelTypes["order_by"] | undefined | null,
 	created_at?: ModelTypes["order_by"] | undefined | null,
 	id?: ModelTypes["order_by"] | undefined | null,
 	map?: ModelTypes["maps_order_by"] | undefined | null,
@@ -149033,8 +149408,11 @@ export type ModelTypes = {
 	id: ModelTypes["uuid"]
 };
 	["match_map_veto_picks_select_column"]:match_map_veto_picks_select_column;
+	["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]:match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns;
+	["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]:match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns;
 	/** input type for updating data in table "match_map_veto_picks" */
 ["match_map_veto_picks_set_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
 	map_id?: ModelTypes["uuid"] | undefined | null,
@@ -149052,6 +149430,7 @@ export type ModelTypes = {
 };
 	/** Initial value of the column from where the streaming should start */
 ["match_map_veto_picks_stream_cursor_value_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
 	map_id?: ModelTypes["uuid"] | undefined | null,
@@ -149071,6 +149450,7 @@ export type ModelTypes = {
 ["match_maps"]: {
 		clips_count: number,
 	created_at: ModelTypes["timestamptz"],
+	demo_processing_started_at?: ModelTypes["timestamptz"] | undefined | null,
 	/** An array relationship */
 	demos: Array<ModelTypes["match_map_demos"]>,
 	/** An aggregate relationship */
@@ -149224,6 +149604,7 @@ export type ModelTypes = {
 	_or?: Array<ModelTypes["match_maps_bool_exp"]> | undefined | null,
 	clips_count?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	created_at?: ModelTypes["timestamptz_comparison_exp"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["timestamptz_comparison_exp"] | undefined | null,
 	demos?: ModelTypes["match_map_demos_bool_exp"] | undefined | null,
 	demos_aggregate?: ModelTypes["match_map_demos_aggregate_bool_exp"] | undefined | null,
 	demos_download_url?: ModelTypes["String_comparison_exp"] | undefined | null,
@@ -149283,6 +149664,7 @@ export type ModelTypes = {
 ["match_maps_insert_input"]: {
 	clips_count?: number | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["timestamptz"] | undefined | null,
 	demos?: ModelTypes["match_map_demos_arr_rel_insert_input"] | undefined | null,
 	e_match_map_status?: ModelTypes["e_match_map_status_obj_rel_insert_input"] | undefined | null,
 	ended_at?: ModelTypes["timestamptz"] | undefined | null,
@@ -149317,6 +149699,7 @@ export type ModelTypes = {
 ["match_maps_max_fields"]: {
 		clips_count?: number | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "match_map_demo_download_url" */
 	demos_download_url?: string | undefined | null,
 	/** A computed field, executes function "match_map_demo_total_size" */
@@ -149342,6 +149725,7 @@ export type ModelTypes = {
 ["match_maps_max_order_by"]: {
 	clips_count?: ModelTypes["order_by"] | undefined | null,
 	created_at?: ModelTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["order_by"] | undefined | null,
 	ended_at?: ModelTypes["order_by"] | undefined | null,
 	id?: ModelTypes["order_by"] | undefined | null,
 	latest_clip_at?: ModelTypes["order_by"] | undefined | null,
@@ -149359,6 +149743,7 @@ export type ModelTypes = {
 ["match_maps_min_fields"]: {
 		clips_count?: number | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "match_map_demo_download_url" */
 	demos_download_url?: string | undefined | null,
 	/** A computed field, executes function "match_map_demo_total_size" */
@@ -149384,6 +149769,7 @@ export type ModelTypes = {
 ["match_maps_min_order_by"]: {
 	clips_count?: ModelTypes["order_by"] | undefined | null,
 	created_at?: ModelTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["order_by"] | undefined | null,
 	ended_at?: ModelTypes["order_by"] | undefined | null,
 	id?: ModelTypes["order_by"] | undefined | null,
 	latest_clip_at?: ModelTypes["order_by"] | undefined | null,
@@ -149420,6 +149806,7 @@ export type ModelTypes = {
 ["match_maps_order_by"]: {
 	clips_count?: ModelTypes["order_by"] | undefined | null,
 	created_at?: ModelTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["order_by"] | undefined | null,
 	demos_aggregate?: ModelTypes["match_map_demos_aggregate_order_by"] | undefined | null,
 	demos_download_url?: ModelTypes["order_by"] | undefined | null,
 	demos_total_size?: ModelTypes["order_by"] | undefined | null,
@@ -149464,6 +149851,7 @@ export type ModelTypes = {
 ["match_maps_set_input"]: {
 	clips_count?: number | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["timestamptz"] | undefined | null,
 	ended_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
 	latest_clip_at?: ModelTypes["timestamptz"] | undefined | null,
@@ -149557,6 +149945,7 @@ export type ModelTypes = {
 ["match_maps_stream_cursor_value_input"]: {
 	clips_count?: number | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: ModelTypes["timestamptz"] | undefined | null,
 	ended_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
 	latest_clip_at?: ModelTypes["timestamptz"] | undefined | null,
@@ -149711,7 +150100,8 @@ export type ModelTypes = {
 	/** An object relationship */
 	tournament_stage?: ModelTypes["tournament_stages"] | undefined | null,
 	tv_delay: number,
-	type: ModelTypes["e_match_types_enum"]
+	type: ModelTypes["e_match_types_enum"],
+	veto_pick_timeout: number
 };
 	/** aggregated selection of "match_options" */
 ["match_options_aggregate"]: {
@@ -149740,7 +150130,8 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** Boolean expression to filter rows from the table "match_options". All fields are combined with a logical 'AND'. */
 ["match_options_bool_exp"]: {
@@ -149779,7 +150170,8 @@ export type ModelTypes = {
 	tournament_bracket?: ModelTypes["tournament_brackets_bool_exp"] | undefined | null,
 	tournament_stage?: ModelTypes["tournament_stages_bool_exp"] | undefined | null,
 	tv_delay?: ModelTypes["Int_comparison_exp"] | undefined | null,
-	type?: ModelTypes["e_match_types_enum_comparison_exp"] | undefined | null
+	type?: ModelTypes["e_match_types_enum_comparison_exp"] | undefined | null,
+	veto_pick_timeout?: ModelTypes["Int_comparison_exp"] | undefined | null
 };
 	["match_options_constraint"]:match_options_constraint;
 	/** input type for incrementing numeric columns in table "match_options" */
@@ -149790,7 +150182,8 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** input type for inserting data into table "match_options" */
 ["match_options_insert_input"]: {
@@ -149824,7 +150217,8 @@ export type ModelTypes = {
 	tournament_bracket?: ModelTypes["tournament_brackets_obj_rel_insert_input"] | undefined | null,
 	tournament_stage?: ModelTypes["tournament_stages_obj_rel_insert_input"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: ModelTypes["e_match_types_enum"] | undefined | null
+	type?: ModelTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate max on columns */
 ["match_options_max_fields"]: {
@@ -149838,7 +150232,8 @@ export type ModelTypes = {
 	number_of_substitutes?: number | undefined | null,
 	regions?: Array<string> | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate min on columns */
 ["match_options_min_fields"]: {
@@ -149852,7 +150247,8 @@ export type ModelTypes = {
 	number_of_substitutes?: number | undefined | null,
 	regions?: Array<string> | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** response of any mutation on the table "match_options" */
 ["match_options_mutation_response"]: {
@@ -149906,7 +150302,8 @@ export type ModelTypes = {
 	tournament_bracket?: ModelTypes["tournament_brackets_order_by"] | undefined | null,
 	tournament_stage?: ModelTypes["tournament_stages_order_by"] | undefined | null,
 	tv_delay?: ModelTypes["order_by"] | undefined | null,
-	type?: ModelTypes["order_by"] | undefined | null
+	type?: ModelTypes["order_by"] | undefined | null,
+	veto_pick_timeout?: ModelTypes["order_by"] | undefined | null
 };
 	/** primary key columns input for table: match_options */
 ["match_options_pk_columns_input"]: {
@@ -149940,7 +150337,8 @@ export type ModelTypes = {
 	tech_timeout_setting?: ModelTypes["e_timeout_settings_enum"] | undefined | null,
 	timeout_setting?: ModelTypes["e_timeout_settings_enum"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: ModelTypes["e_match_types_enum"] | undefined | null
+	type?: ModelTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate stddev on columns */
 ["match_options_stddev_fields"]: {
@@ -149950,7 +150348,8 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate stddev_pop on columns */
 ["match_options_stddev_pop_fields"]: {
@@ -149960,7 +150359,8 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate stddev_samp on columns */
 ["match_options_stddev_samp_fields"]: {
@@ -149970,7 +150370,8 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** Streaming cursor of the table "match_options" */
 ["match_options_stream_cursor_input"]: {
@@ -150006,7 +150407,8 @@ export type ModelTypes = {
 	tech_timeout_setting?: ModelTypes["e_timeout_settings_enum"] | undefined | null,
 	timeout_setting?: ModelTypes["e_timeout_settings_enum"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: ModelTypes["e_match_types_enum"] | undefined | null
+	type?: ModelTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate sum on columns */
 ["match_options_sum_fields"]: {
@@ -150016,7 +150418,8 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	["match_options_update_column"]:match_options_update_column;
 	["match_options_updates"]: {
@@ -150035,7 +150438,8 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate var_samp on columns */
 ["match_options_var_samp_fields"]: {
@@ -150045,7 +150449,8 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate variance on columns */
 ["match_options_variance_fields"]: {
@@ -150055,11 +150460,13 @@ export type ModelTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** columns and relationships of "match_region_veto_picks" */
 ["match_region_veto_picks"]: {
-		created_at: ModelTypes["timestamptz"],
+		auto_picked: boolean,
+	created_at: ModelTypes["timestamptz"],
 	id: ModelTypes["uuid"],
 	/** An object relationship */
 	match: ModelTypes["matches"],
@@ -150076,7 +150483,21 @@ export type ModelTypes = {
 	nodes: Array<ModelTypes["match_region_veto_picks"]>
 };
 	["match_region_veto_picks_aggregate_bool_exp"]: {
+	bool_and?: ModelTypes["match_region_veto_picks_aggregate_bool_exp_bool_and"] | undefined | null,
+	bool_or?: ModelTypes["match_region_veto_picks_aggregate_bool_exp_bool_or"] | undefined | null,
 	count?: ModelTypes["match_region_veto_picks_aggregate_bool_exp_count"] | undefined | null
+};
+	["match_region_veto_picks_aggregate_bool_exp_bool_and"]: {
+	arguments: ModelTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: ModelTypes["match_region_veto_picks_bool_exp"] | undefined | null,
+	predicate: ModelTypes["Boolean_comparison_exp"]
+};
+	["match_region_veto_picks_aggregate_bool_exp_bool_or"]: {
+	arguments: ModelTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: ModelTypes["match_region_veto_picks_bool_exp"] | undefined | null,
+	predicate: ModelTypes["Boolean_comparison_exp"]
 };
 	["match_region_veto_picks_aggregate_bool_exp_count"]: {
 	arguments?: Array<ModelTypes["match_region_veto_picks_select_column"]> | undefined | null,
@@ -150107,6 +150528,7 @@ export type ModelTypes = {
 	_and?: Array<ModelTypes["match_region_veto_picks_bool_exp"]> | undefined | null,
 	_not?: ModelTypes["match_region_veto_picks_bool_exp"] | undefined | null,
 	_or?: Array<ModelTypes["match_region_veto_picks_bool_exp"]> | undefined | null,
+	auto_picked?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	created_at?: ModelTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: ModelTypes["uuid_comparison_exp"] | undefined | null,
 	match?: ModelTypes["matches_bool_exp"] | undefined | null,
@@ -150119,6 +150541,7 @@ export type ModelTypes = {
 	["match_region_veto_picks_constraint"]:match_region_veto_picks_constraint;
 	/** input type for inserting data into table "match_region_veto_picks" */
 ["match_region_veto_picks_insert_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
 	match?: ModelTypes["matches_obj_rel_insert_input"] | undefined | null,
@@ -150175,6 +150598,7 @@ export type ModelTypes = {
 };
 	/** Ordering options when selecting data from "match_region_veto_picks". */
 ["match_region_veto_picks_order_by"]: {
+	auto_picked?: ModelTypes["order_by"] | undefined | null,
 	created_at?: ModelTypes["order_by"] | undefined | null,
 	id?: ModelTypes["order_by"] | undefined | null,
 	match?: ModelTypes["matches_order_by"] | undefined | null,
@@ -150189,8 +150613,11 @@ export type ModelTypes = {
 	id: ModelTypes["uuid"]
 };
 	["match_region_veto_picks_select_column"]:match_region_veto_picks_select_column;
+	["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]:match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns;
+	["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]:match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns;
 	/** input type for updating data in table "match_region_veto_picks" */
 ["match_region_veto_picks_set_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
 	match_id?: ModelTypes["uuid"] | undefined | null,
@@ -150207,6 +150634,7 @@ export type ModelTypes = {
 };
 	/** Initial value of the column from where the streaming should start */
 ["match_region_veto_picks_stream_cursor_value_input"]: {
+	auto_picked?: boolean | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
 	id?: ModelTypes["uuid"] | undefined | null,
 	match_id?: ModelTypes["uuid"] | undefined | null,
@@ -150858,6 +151286,7 @@ export type ModelTypes = {
 	tournament_brackets_aggregate: ModelTypes["tournament_brackets_aggregate"],
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?: string | undefined | null,
+	veto_pick_expires_at?: ModelTypes["timestamptz"] | undefined | null,
 	/** An object relationship */
 	winner?: ModelTypes["match_lineups"] | undefined | null,
 	winning_lineup_id?: ModelTypes["uuid"] | undefined | null
@@ -151020,6 +151449,7 @@ export type ModelTypes = {
 	tournament_brackets?: ModelTypes["tournament_brackets_bool_exp"] | undefined | null,
 	tournament_brackets_aggregate?: ModelTypes["tournament_brackets_aggregate_bool_exp"] | undefined | null,
 	tv_connection_string?: ModelTypes["String_comparison_exp"] | undefined | null,
+	veto_pick_expires_at?: ModelTypes["timestamptz_comparison_exp"] | undefined | null,
 	winner?: ModelTypes["match_lineups_bool_exp"] | undefined | null,
 	winning_lineup_id?: ModelTypes["uuid_comparison_exp"] | undefined | null
 };
@@ -151073,6 +151503,7 @@ export type ModelTypes = {
 	status?: ModelTypes["e_match_status_enum"] | undefined | null,
 	streams?: ModelTypes["match_streams_arr_rel_insert_input"] | undefined | null,
 	tournament_brackets?: ModelTypes["tournament_brackets_arr_rel_insert_input"] | undefined | null,
+	veto_pick_expires_at?: ModelTypes["timestamptz"] | undefined | null,
 	winner?: ModelTypes["match_lineups_obj_rel_insert_input"] | undefined | null,
 	winning_lineup_id?: ModelTypes["uuid"] | undefined | null
 };
@@ -151123,6 +151554,7 @@ export type ModelTypes = {
 	started_at?: ModelTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?: string | undefined | null,
+	veto_pick_expires_at?: ModelTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: ModelTypes["uuid"] | undefined | null
 };
 	/** order by max() on columns of table "matches" */
@@ -151146,6 +151578,7 @@ export type ModelTypes = {
 	share_code?: ModelTypes["order_by"] | undefined | null,
 	source?: ModelTypes["order_by"] | undefined | null,
 	started_at?: ModelTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: ModelTypes["order_by"] | undefined | null,
 	winning_lineup_id?: ModelTypes["order_by"] | undefined | null
 };
 	/** aggregate min on columns */
@@ -151195,6 +151628,7 @@ export type ModelTypes = {
 	started_at?: ModelTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?: string | undefined | null,
+	veto_pick_expires_at?: ModelTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: ModelTypes["uuid"] | undefined | null
 };
 	/** order by min() on columns of table "matches" */
@@ -151218,6 +151652,7 @@ export type ModelTypes = {
 	share_code?: ModelTypes["order_by"] | undefined | null,
 	source?: ModelTypes["order_by"] | undefined | null,
 	started_at?: ModelTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: ModelTypes["order_by"] | undefined | null,
 	winning_lineup_id?: ModelTypes["order_by"] | undefined | null
 };
 	/** response of any mutation on the table "matches" */
@@ -151317,6 +151752,7 @@ export type ModelTypes = {
 	teams_aggregate?: ModelTypes["teams_aggregate_order_by"] | undefined | null,
 	tournament_brackets_aggregate?: ModelTypes["tournament_brackets_aggregate_order_by"] | undefined | null,
 	tv_connection_string?: ModelTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: ModelTypes["order_by"] | undefined | null,
 	winner?: ModelTypes["match_lineups_order_by"] | undefined | null,
 	winning_lineup_id?: ModelTypes["order_by"] | undefined | null
 };
@@ -151346,6 +151782,7 @@ export type ModelTypes = {
 	source?: string | undefined | null,
 	started_at?: ModelTypes["timestamptz"] | undefined | null,
 	status?: ModelTypes["e_match_status_enum"] | undefined | null,
+	veto_pick_expires_at?: ModelTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: ModelTypes["uuid"] | undefined | null
 };
 	/** aggregate stddev on columns */
@@ -151413,6 +151850,7 @@ export type ModelTypes = {
 	source?: string | undefined | null,
 	started_at?: ModelTypes["timestamptz"] | undefined | null,
 	status?: ModelTypes["e_match_status_enum"] | undefined | null,
+	veto_pick_expires_at?: ModelTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: ModelTypes["uuid"] | undefined | null
 };
 	/** aggregate sum on columns */
@@ -152253,6 +152691,7 @@ export type ModelTypes = {
 	/** delete single row from the table: "v_team_stage_results" */
 	delete_v_team_stage_results_by_pk?: ModelTypes["v_team_stage_results"] | undefined | null,
 	denyInvite?: ModelTypes["SuccessOutput"] | undefined | null,
+	denyNameChange?: ModelTypes["SuccessOutput"] | undefined | null,
 	forfeitMatch?: ModelTypes["SuccessOutput"] | undefined | null,
 	/** Live pod GSI snapshot — slots, sides, alive/dead. Drives the stream-deck. */
 	getLiveStreamSpecState?: ModelTypes["LiveStreamSpecState"] | undefined | null,
@@ -167212,6 +167651,8 @@ export type ModelTypes = {
 	awards: Array<ModelTypes["award_recipients"]>,
 	/** An aggregate relationship */
 	awards_aggregate: ModelTypes["award_recipients_aggregate"],
+	/** A computed field, executes function "banned_until" */
+	banned_until?: ModelTypes["timestamptz"] | undefined | null,
 	/** An array relationship */
 	coach_lineups: Array<ModelTypes["match_lineups"]>,
 	/** An aggregate relationship */
@@ -167272,6 +167713,8 @@ export type ModelTypes = {
 	invited_players: Array<ModelTypes["team_invites"]>,
 	/** An aggregate relationship */
 	invited_players_aggregate: ModelTypes["team_invites_aggregate"],
+	/** A computed field, executes function "is_admin_sanctioned" */
+	is_admin_sanctioned?: boolean | undefined | null,
 	/** A computed field, executes function "is_banned" */
 	is_banned?: boolean | undefined | null,
 	/** A computed field, executes function "is_gagged" */
@@ -167284,6 +167727,8 @@ export type ModelTypes = {
 	is_in_lobby?: boolean | undefined | null,
 	/** A computed field, executes function "is_muted" */
 	is_muted?: boolean | undefined | null,
+	/** A computed field, executes function "is_registered" */
+	is_registered?: boolean | undefined | null,
 	/** An array relationship */
 	kills: Array<ModelTypes["player_kills"]>,
 	/** An aggregate relationship */
@@ -167483,6 +167928,7 @@ export type ModelTypes = {
 	avatar_url?: ModelTypes["String_comparison_exp"] | undefined | null,
 	awards?: ModelTypes["award_recipients_bool_exp"] | undefined | null,
 	awards_aggregate?: ModelTypes["award_recipients_aggregate_bool_exp"] | undefined | null,
+	banned_until?: ModelTypes["timestamptz_comparison_exp"] | undefined | null,
 	coach_lineups?: ModelTypes["match_lineups_bool_exp"] | undefined | null,
 	coach_lineups_aggregate?: ModelTypes["match_lineups_aggregate_bool_exp"] | undefined | null,
 	country?: ModelTypes["String_comparison_exp"] | undefined | null,
@@ -167519,12 +167965,14 @@ export type ModelTypes = {
 	game_ban_count?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	invited_players?: ModelTypes["team_invites_bool_exp"] | undefined | null,
 	invited_players_aggregate?: ModelTypes["team_invites_aggregate_bool_exp"] | undefined | null,
+	is_admin_sanctioned?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	is_banned?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	is_gagged?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_another_match?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_draft?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_lobby?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	is_muted?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
+	is_registered?: ModelTypes["Boolean_comparison_exp"] | undefined | null,
 	kills?: ModelTypes["player_kills_bool_exp"] | undefined | null,
 	kills_aggregate?: ModelTypes["player_kills_aggregate_bool_exp"] | undefined | null,
 	kills_by_weapons?: ModelTypes["player_kills_by_weapon_bool_exp"] | undefined | null,
@@ -167686,6 +168134,8 @@ export type ModelTypes = {
 	/** aggregate max on columns */
 ["players_max_fields"]: {
 		avatar_url?: string | undefined | null,
+	/** A computed field, executes function "banned_until" */
+	banned_until?: ModelTypes["timestamptz"] | undefined | null,
 	country?: string | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "get_player_current_lobby_id" */
@@ -167735,6 +168185,8 @@ export type ModelTypes = {
 	/** aggregate min on columns */
 ["players_min_fields"]: {
 		avatar_url?: string | undefined | null,
+	/** A computed field, executes function "banned_until" */
+	banned_until?: ModelTypes["timestamptz"] | undefined | null,
 	country?: string | undefined | null,
 	created_at?: ModelTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "get_player_current_lobby_id" */
@@ -167808,6 +168260,7 @@ export type ModelTypes = {
 	assited_by_players_aggregate?: ModelTypes["player_assists_aggregate_order_by"] | undefined | null,
 	avatar_url?: ModelTypes["order_by"] | undefined | null,
 	awards_aggregate?: ModelTypes["award_recipients_aggregate_order_by"] | undefined | null,
+	banned_until?: ModelTypes["order_by"] | undefined | null,
 	coach_lineups_aggregate?: ModelTypes["match_lineups_aggregate_order_by"] | undefined | null,
 	country?: ModelTypes["order_by"] | undefined | null,
 	created_at?: ModelTypes["order_by"] | undefined | null,
@@ -167833,12 +168286,14 @@ export type ModelTypes = {
 	friends_aggregate?: ModelTypes["my_friends_aggregate_order_by"] | undefined | null,
 	game_ban_count?: ModelTypes["order_by"] | undefined | null,
 	invited_players_aggregate?: ModelTypes["team_invites_aggregate_order_by"] | undefined | null,
+	is_admin_sanctioned?: ModelTypes["order_by"] | undefined | null,
 	is_banned?: ModelTypes["order_by"] | undefined | null,
 	is_gagged?: ModelTypes["order_by"] | undefined | null,
 	is_in_another_match?: ModelTypes["order_by"] | undefined | null,
 	is_in_draft?: ModelTypes["order_by"] | undefined | null,
 	is_in_lobby?: ModelTypes["order_by"] | undefined | null,
 	is_muted?: ModelTypes["order_by"] | undefined | null,
+	is_registered?: ModelTypes["order_by"] | undefined | null,
 	kills_aggregate?: ModelTypes["player_kills_aggregate_order_by"] | undefined | null,
 	kills_by_weapons_aggregate?: ModelTypes["player_kills_by_weapon_aggregate_order_by"] | undefined | null,
 	language?: ModelTypes["order_by"] | undefined | null,
@@ -185791,10 +186246,12 @@ export type ModelTypes = {
 };
 	/** columns and relationships of "v_team_ranks" */
 ["v_team_ranks"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: ModelTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: ModelTypes["bigint"] | undefined | null,
@@ -185823,10 +186280,12 @@ export type ModelTypes = {
 };
 	/** aggregate avg on columns */
 ["v_team_ranks_avg_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -185836,10 +186295,12 @@ export type ModelTypes = {
 	_and?: Array<ModelTypes["v_team_ranks_bool_exp"]> | undefined | null,
 	_not?: ModelTypes["v_team_ranks_bool_exp"] | undefined | null,
 	_or?: Array<ModelTypes["v_team_ranks_bool_exp"]> | undefined | null,
+	avg_duel_elo?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	avg_elo?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	avg_faceit_elo?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	avg_faceit_level?: ModelTypes["float8_comparison_exp"] | undefined | null,
 	avg_premier?: ModelTypes["Int_comparison_exp"] | undefined | null,
+	avg_wingman_elo?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	max_elo?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	min_elo?: ModelTypes["Int_comparison_exp"] | undefined | null,
 	roster_size?: ModelTypes["bigint_comparison_exp"] | undefined | null,
@@ -185848,10 +186309,12 @@ export type ModelTypes = {
 };
 	/** input type for inserting data into table "v_team_ranks" */
 ["v_team_ranks_insert_input"]: {
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: ModelTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: ModelTypes["bigint"] | undefined | null,
@@ -185860,10 +186323,12 @@ export type ModelTypes = {
 };
 	/** aggregate max on columns */
 ["v_team_ranks_max_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: ModelTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: ModelTypes["bigint"] | undefined | null,
@@ -185871,10 +186336,12 @@ export type ModelTypes = {
 };
 	/** aggregate min on columns */
 ["v_team_ranks_min_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: ModelTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: ModelTypes["bigint"] | undefined | null,
@@ -185886,10 +186353,12 @@ export type ModelTypes = {
 };
 	/** Ordering options when selecting data from "v_team_ranks". */
 ["v_team_ranks_order_by"]: {
+	avg_duel_elo?: ModelTypes["order_by"] | undefined | null,
 	avg_elo?: ModelTypes["order_by"] | undefined | null,
 	avg_faceit_elo?: ModelTypes["order_by"] | undefined | null,
 	avg_faceit_level?: ModelTypes["order_by"] | undefined | null,
 	avg_premier?: ModelTypes["order_by"] | undefined | null,
+	avg_wingman_elo?: ModelTypes["order_by"] | undefined | null,
 	max_elo?: ModelTypes["order_by"] | undefined | null,
 	min_elo?: ModelTypes["order_by"] | undefined | null,
 	roster_size?: ModelTypes["order_by"] | undefined | null,
@@ -185899,30 +186368,36 @@ export type ModelTypes = {
 	["v_team_ranks_select_column"]:v_team_ranks_select_column;
 	/** aggregate stddev on columns */
 ["v_team_ranks_stddev_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
 };
 	/** aggregate stddev_pop on columns */
 ["v_team_ranks_stddev_pop_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
 };
 	/** aggregate stddev_samp on columns */
 ["v_team_ranks_stddev_samp_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -185936,10 +186411,12 @@ export type ModelTypes = {
 };
 	/** Initial value of the column from where the streaming should start */
 ["v_team_ranks_stream_cursor_value_input"]: {
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: ModelTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: ModelTypes["bigint"] | undefined | null,
@@ -185947,40 +186424,48 @@ export type ModelTypes = {
 };
 	/** aggregate sum on columns */
 ["v_team_ranks_sum_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: ModelTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: ModelTypes["bigint"] | undefined | null
 };
 	/** aggregate var_pop on columns */
 ["v_team_ranks_var_pop_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
 };
 	/** aggregate var_samp on columns */
 ["v_team_ranks_var_samp_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
 };
 	/** aggregate variance on columns */
 ["v_team_ranks_variance_fields"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -188764,6 +189249,9 @@ export type GraphQLTypes = {
 	__typename: "abandoned_matches",
 	abandoned_at: GraphQLTypes["timestamptz"],
 	id: GraphQLTypes["uuid"],
+	/** An object relationship */
+	match?: GraphQLTypes["matches"] | undefined | null,
+	match_id?: GraphQLTypes["uuid"] | undefined | null,
 	steam_id: GraphQLTypes["bigint"]
 };
 	/** aggregated selection of "abandoned_matches" */
@@ -188832,6 +189320,8 @@ export type GraphQLTypes = {
 	_or?: Array<GraphQLTypes["abandoned_matches_bool_exp"]> | undefined | null,
 	abandoned_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: GraphQLTypes["uuid_comparison_exp"] | undefined | null,
+	match?: GraphQLTypes["matches_bool_exp"] | undefined | null,
+	match_id?: GraphQLTypes["uuid_comparison_exp"] | undefined | null,
 	steam_id?: GraphQLTypes["bigint_comparison_exp"] | undefined | null
 };
 	/** unique or primary key constraints on table "abandoned_matches" */
@@ -188844,6 +189334,8 @@ export type GraphQLTypes = {
 ["abandoned_matches_insert_input"]: {
 		abandoned_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
+	match?: GraphQLTypes["matches_obj_rel_insert_input"] | undefined | null,
+	match_id?: GraphQLTypes["uuid"] | undefined | null,
 	steam_id?: GraphQLTypes["bigint"] | undefined | null
 };
 	/** aggregate max on columns */
@@ -188851,12 +189343,14 @@ export type GraphQLTypes = {
 	__typename: "abandoned_matches_max_fields",
 	abandoned_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
+	match_id?: GraphQLTypes["uuid"] | undefined | null,
 	steam_id?: GraphQLTypes["bigint"] | undefined | null
 };
 	/** order by max() on columns of table "abandoned_matches" */
 ["abandoned_matches_max_order_by"]: {
 		abandoned_at?: GraphQLTypes["order_by"] | undefined | null,
 	id?: GraphQLTypes["order_by"] | undefined | null,
+	match_id?: GraphQLTypes["order_by"] | undefined | null,
 	steam_id?: GraphQLTypes["order_by"] | undefined | null
 };
 	/** aggregate min on columns */
@@ -188864,12 +189358,14 @@ export type GraphQLTypes = {
 	__typename: "abandoned_matches_min_fields",
 	abandoned_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
+	match_id?: GraphQLTypes["uuid"] | undefined | null,
 	steam_id?: GraphQLTypes["bigint"] | undefined | null
 };
 	/** order by min() on columns of table "abandoned_matches" */
 ["abandoned_matches_min_order_by"]: {
 		abandoned_at?: GraphQLTypes["order_by"] | undefined | null,
 	id?: GraphQLTypes["order_by"] | undefined | null,
+	match_id?: GraphQLTypes["order_by"] | undefined | null,
 	steam_id?: GraphQLTypes["order_by"] | undefined | null
 };
 	/** response of any mutation on the table "abandoned_matches" */
@@ -188890,6 +189386,8 @@ export type GraphQLTypes = {
 ["abandoned_matches_order_by"]: {
 		abandoned_at?: GraphQLTypes["order_by"] | undefined | null,
 	id?: GraphQLTypes["order_by"] | undefined | null,
+	match?: GraphQLTypes["matches_order_by"] | undefined | null,
+	match_id?: GraphQLTypes["order_by"] | undefined | null,
 	steam_id?: GraphQLTypes["order_by"] | undefined | null
 };
 	/** primary key columns input for table: abandoned_matches */
@@ -188902,6 +189400,7 @@ export type GraphQLTypes = {
 ["abandoned_matches_set_input"]: {
 		abandoned_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
+	match_id?: GraphQLTypes["uuid"] | undefined | null,
 	steam_id?: GraphQLTypes["bigint"] | undefined | null
 };
 	/** aggregate stddev on columns */
@@ -188942,6 +189441,7 @@ export type GraphQLTypes = {
 ["abandoned_matches_stream_cursor_value_input"]: {
 		abandoned_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
+	match_id?: GraphQLTypes["uuid"] | undefined | null,
 	steam_id?: GraphQLTypes["bigint"] | undefined | null
 };
 	/** aggregate sum on columns */
@@ -200458,6 +200958,7 @@ export type GraphQLTypes = {
 	_match_type?: string | undefined | null,
 	_role?: string | undefined | null,
 	_season_id?: GraphQLTypes["uuid"] | undefined | null,
+	_source?: string | undefined | null,
 	_window_days?: number | undefined | null
 };
 	["get_league_season_leaderboard_args"]: {
@@ -200471,6 +200972,7 @@ export type GraphQLTypes = {
 	_match_type?: string | undefined | null,
 	_player_steam_id?: string | undefined | null,
 	_season_id?: GraphQLTypes["uuid"] | undefined | null,
+	_source?: string | undefined | null,
 	_window_days?: number | undefined | null
 };
 	["inet"]: "scalar" & { name: "inet" };
@@ -200532,6 +201034,7 @@ export type GraphQLTypes = {
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name: string,
 	player_steam_id: string,
 	secondary_value?: GraphQLTypes["float8"] | undefined | null,
@@ -200574,6 +201077,7 @@ export type GraphQLTypes = {
 	matches_played?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	player_avatar_url?: GraphQLTypes["String_comparison_exp"] | undefined | null,
 	player_country?: GraphQLTypes["String_comparison_exp"] | undefined | null,
+	player_custom_avatar_url?: GraphQLTypes["String_comparison_exp"] | undefined | null,
 	player_name?: GraphQLTypes["String_comparison_exp"] | undefined | null,
 	player_steam_id?: GraphQLTypes["String_comparison_exp"] | undefined | null,
 	secondary_value?: GraphQLTypes["float8_comparison_exp"] | undefined | null,
@@ -200592,6 +201096,7 @@ export type GraphQLTypes = {
 		matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: GraphQLTypes["float8"] | undefined | null,
@@ -200604,6 +201109,7 @@ export type GraphQLTypes = {
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: GraphQLTypes["float8"] | undefined | null,
@@ -200616,6 +201122,7 @@ export type GraphQLTypes = {
 	matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: GraphQLTypes["float8"] | undefined | null,
@@ -200635,6 +201142,7 @@ export type GraphQLTypes = {
 		matches_played?: GraphQLTypes["order_by"] | undefined | null,
 	player_avatar_url?: GraphQLTypes["order_by"] | undefined | null,
 	player_country?: GraphQLTypes["order_by"] | undefined | null,
+	player_custom_avatar_url?: GraphQLTypes["order_by"] | undefined | null,
 	player_name?: GraphQLTypes["order_by"] | undefined | null,
 	player_steam_id?: GraphQLTypes["order_by"] | undefined | null,
 	secondary_value?: GraphQLTypes["order_by"] | undefined | null,
@@ -200648,6 +201156,7 @@ export type GraphQLTypes = {
 		matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: GraphQLTypes["float8"] | undefined | null,
@@ -200690,6 +201199,7 @@ export type GraphQLTypes = {
 		matches_played?: number | undefined | null,
 	player_avatar_url?: string | undefined | null,
 	player_country?: string | undefined | null,
+	player_custom_avatar_url?: string | undefined | null,
 	player_name?: string | undefined | null,
 	player_steam_id?: string | undefined | null,
 	secondary_value?: GraphQLTypes["float8"] | undefined | null,
@@ -205455,6 +205965,7 @@ export type GraphQLTypes = {
 	checked_in: boolean,
 	discord_id?: string | undefined | null,
 	id: GraphQLTypes["uuid"],
+	is_connected: boolean,
 	/** An object relationship */
 	lineup: GraphQLTypes["match_lineups"],
 	match_lineup_id: GraphQLTypes["uuid"],
@@ -205547,6 +206058,7 @@ export type GraphQLTypes = {
 	checked_in?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	discord_id?: GraphQLTypes["String_comparison_exp"] | undefined | null,
 	id?: GraphQLTypes["uuid_comparison_exp"] | undefined | null,
+	is_connected?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	lineup?: GraphQLTypes["match_lineups_bool_exp"] | undefined | null,
 	match_lineup_id?: GraphQLTypes["uuid_comparison_exp"] | undefined | null,
 	party_id?: GraphQLTypes["uuid_comparison_exp"] | undefined | null,
@@ -205567,6 +206079,7 @@ export type GraphQLTypes = {
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	lineup?: GraphQLTypes["match_lineups_obj_rel_insert_input"] | undefined | null,
 	match_lineup_id?: GraphQLTypes["uuid"] | undefined | null,
 	party_id?: GraphQLTypes["uuid"] | undefined | null,
@@ -205633,6 +206146,7 @@ export type GraphQLTypes = {
 	checked_in?: GraphQLTypes["order_by"] | undefined | null,
 	discord_id?: GraphQLTypes["order_by"] | undefined | null,
 	id?: GraphQLTypes["order_by"] | undefined | null,
+	is_connected?: GraphQLTypes["order_by"] | undefined | null,
 	lineup?: GraphQLTypes["match_lineups_order_by"] | undefined | null,
 	match_lineup_id?: GraphQLTypes["order_by"] | undefined | null,
 	party_id?: GraphQLTypes["order_by"] | undefined | null,
@@ -205657,6 +206171,7 @@ export type GraphQLTypes = {
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	match_lineup_id?: GraphQLTypes["uuid"] | undefined | null,
 	party_id?: GraphQLTypes["uuid"] | undefined | null,
 	party_source?: GraphQLTypes["e_match_party_sources_enum"] | undefined | null,
@@ -205703,6 +206218,7 @@ export type GraphQLTypes = {
 	checked_in?: boolean | undefined | null,
 	discord_id?: string | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
+	is_connected?: boolean | undefined | null,
 	match_lineup_id?: GraphQLTypes["uuid"] | undefined | null,
 	party_id?: GraphQLTypes["uuid"] | undefined | null,
 	party_source?: GraphQLTypes["e_match_party_sources_enum"] | undefined | null,
@@ -207138,6 +207654,7 @@ export type GraphQLTypes = {
 	/** columns and relationships of "match_map_veto_picks" */
 ["match_map_veto_picks"]: {
 	__typename: "match_map_veto_picks",
+	auto_picked: boolean,
 	created_at: GraphQLTypes["timestamptz"],
 	id: GraphQLTypes["uuid"],
 	/** An object relationship */
@@ -207159,7 +207676,21 @@ export type GraphQLTypes = {
 	nodes: Array<GraphQLTypes["match_map_veto_picks"]>
 };
 	["match_map_veto_picks_aggregate_bool_exp"]: {
-		count?: GraphQLTypes["match_map_veto_picks_aggregate_bool_exp_count"] | undefined | null
+		bool_and?: GraphQLTypes["match_map_veto_picks_aggregate_bool_exp_bool_and"] | undefined | null,
+	bool_or?: GraphQLTypes["match_map_veto_picks_aggregate_bool_exp_bool_or"] | undefined | null,
+	count?: GraphQLTypes["match_map_veto_picks_aggregate_bool_exp_count"] | undefined | null
+};
+	["match_map_veto_picks_aggregate_bool_exp_bool_and"]: {
+		arguments: GraphQLTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: GraphQLTypes["match_map_veto_picks_bool_exp"] | undefined | null,
+	predicate: GraphQLTypes["Boolean_comparison_exp"]
+};
+	["match_map_veto_picks_aggregate_bool_exp_bool_or"]: {
+		arguments: GraphQLTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: GraphQLTypes["match_map_veto_picks_bool_exp"] | undefined | null,
+	predicate: GraphQLTypes["Boolean_comparison_exp"]
 };
 	["match_map_veto_picks_aggregate_bool_exp_count"]: {
 		arguments?: Array<GraphQLTypes["match_map_veto_picks_select_column"]> | undefined | null,
@@ -207191,6 +207722,7 @@ export type GraphQLTypes = {
 		_and?: Array<GraphQLTypes["match_map_veto_picks_bool_exp"]> | undefined | null,
 	_not?: GraphQLTypes["match_map_veto_picks_bool_exp"] | undefined | null,
 	_or?: Array<GraphQLTypes["match_map_veto_picks_bool_exp"]> | undefined | null,
+	auto_picked?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	created_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: GraphQLTypes["uuid_comparison_exp"] | undefined | null,
 	map?: GraphQLTypes["maps_bool_exp"] | undefined | null,
@@ -207206,7 +207738,8 @@ export type GraphQLTypes = {
 ["match_map_veto_picks_constraint"]: match_map_veto_picks_constraint;
 	/** input type for inserting data into table "match_map_veto_picks" */
 ["match_map_veto_picks_insert_input"]: {
-		created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+		auto_picked?: boolean | undefined | null,
+	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
 	map?: GraphQLTypes["maps_obj_rel_insert_input"] | undefined | null,
 	map_id?: GraphQLTypes["uuid"] | undefined | null,
@@ -207271,7 +207804,8 @@ export type GraphQLTypes = {
 };
 	/** Ordering options when selecting data from "match_map_veto_picks". */
 ["match_map_veto_picks_order_by"]: {
-		created_at?: GraphQLTypes["order_by"] | undefined | null,
+		auto_picked?: GraphQLTypes["order_by"] | undefined | null,
+	created_at?: GraphQLTypes["order_by"] | undefined | null,
 	id?: GraphQLTypes["order_by"] | undefined | null,
 	map?: GraphQLTypes["maps_order_by"] | undefined | null,
 	map_id?: GraphQLTypes["order_by"] | undefined | null,
@@ -207288,9 +207822,14 @@ export type GraphQLTypes = {
 };
 	/** select columns of table "match_map_veto_picks" */
 ["match_map_veto_picks_select_column"]: match_map_veto_picks_select_column;
+	/** select "match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_map_veto_picks" */
+["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]: match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns;
+	/** select "match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_map_veto_picks" */
+["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]: match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns;
 	/** input type for updating data in table "match_map_veto_picks" */
 ["match_map_veto_picks_set_input"]: {
-		created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+		auto_picked?: boolean | undefined | null,
+	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
 	map_id?: GraphQLTypes["uuid"] | undefined | null,
 	match_id?: GraphQLTypes["uuid"] | undefined | null,
@@ -207307,7 +207846,8 @@ export type GraphQLTypes = {
 };
 	/** Initial value of the column from where the streaming should start */
 ["match_map_veto_picks_stream_cursor_value_input"]: {
-		created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+		auto_picked?: boolean | undefined | null,
+	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
 	map_id?: GraphQLTypes["uuid"] | undefined | null,
 	match_id?: GraphQLTypes["uuid"] | undefined | null,
@@ -207328,6 +207868,7 @@ export type GraphQLTypes = {
 	__typename: "match_maps",
 	clips_count: number,
 	created_at: GraphQLTypes["timestamptz"],
+	demo_processing_started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** An array relationship */
 	demos: Array<GraphQLTypes["match_map_demos"]>,
 	/** An aggregate relationship */
@@ -207484,6 +208025,7 @@ export type GraphQLTypes = {
 	_or?: Array<GraphQLTypes["match_maps_bool_exp"]> | undefined | null,
 	clips_count?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	created_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined | null,
 	demos?: GraphQLTypes["match_map_demos_bool_exp"] | undefined | null,
 	demos_aggregate?: GraphQLTypes["match_map_demos_aggregate_bool_exp"] | undefined | null,
 	demos_download_url?: GraphQLTypes["String_comparison_exp"] | undefined | null,
@@ -207544,6 +208086,7 @@ export type GraphQLTypes = {
 ["match_maps_insert_input"]: {
 		clips_count?: number | undefined | null,
 	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	demos?: GraphQLTypes["match_map_demos_arr_rel_insert_input"] | undefined | null,
 	e_match_map_status?: GraphQLTypes["e_match_map_status_obj_rel_insert_input"] | undefined | null,
 	ended_at?: GraphQLTypes["timestamptz"] | undefined | null,
@@ -207579,6 +208122,7 @@ export type GraphQLTypes = {
 	__typename: "match_maps_max_fields",
 	clips_count?: number | undefined | null,
 	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "match_map_demo_download_url" */
 	demos_download_url?: string | undefined | null,
 	/** A computed field, executes function "match_map_demo_total_size" */
@@ -207604,6 +208148,7 @@ export type GraphQLTypes = {
 ["match_maps_max_order_by"]: {
 		clips_count?: GraphQLTypes["order_by"] | undefined | null,
 	created_at?: GraphQLTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["order_by"] | undefined | null,
 	ended_at?: GraphQLTypes["order_by"] | undefined | null,
 	id?: GraphQLTypes["order_by"] | undefined | null,
 	latest_clip_at?: GraphQLTypes["order_by"] | undefined | null,
@@ -207622,6 +208167,7 @@ export type GraphQLTypes = {
 	__typename: "match_maps_min_fields",
 	clips_count?: number | undefined | null,
 	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "match_map_demo_download_url" */
 	demos_download_url?: string | undefined | null,
 	/** A computed field, executes function "match_map_demo_total_size" */
@@ -207647,6 +208193,7 @@ export type GraphQLTypes = {
 ["match_maps_min_order_by"]: {
 		clips_count?: GraphQLTypes["order_by"] | undefined | null,
 	created_at?: GraphQLTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["order_by"] | undefined | null,
 	ended_at?: GraphQLTypes["order_by"] | undefined | null,
 	id?: GraphQLTypes["order_by"] | undefined | null,
 	latest_clip_at?: GraphQLTypes["order_by"] | undefined | null,
@@ -207684,6 +208231,7 @@ export type GraphQLTypes = {
 ["match_maps_order_by"]: {
 		clips_count?: GraphQLTypes["order_by"] | undefined | null,
 	created_at?: GraphQLTypes["order_by"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["order_by"] | undefined | null,
 	demos_aggregate?: GraphQLTypes["match_map_demos_aggregate_order_by"] | undefined | null,
 	demos_download_url?: GraphQLTypes["order_by"] | undefined | null,
 	demos_total_size?: GraphQLTypes["order_by"] | undefined | null,
@@ -207729,6 +208277,7 @@ export type GraphQLTypes = {
 ["match_maps_set_input"]: {
 		clips_count?: number | undefined | null,
 	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	ended_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
 	latest_clip_at?: GraphQLTypes["timestamptz"] | undefined | null,
@@ -207825,6 +208374,7 @@ export type GraphQLTypes = {
 ["match_maps_stream_cursor_value_input"]: {
 		clips_count?: number | undefined | null,
 	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+	demo_processing_started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	ended_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
 	latest_clip_at?: GraphQLTypes["timestamptz"] | undefined | null,
@@ -207985,7 +208535,8 @@ export type GraphQLTypes = {
 	/** An object relationship */
 	tournament_stage?: GraphQLTypes["tournament_stages"] | undefined | null,
 	tv_delay: number,
-	type: GraphQLTypes["e_match_types_enum"]
+	type: GraphQLTypes["e_match_types_enum"],
+	veto_pick_timeout: number
 };
 	/** aggregated selection of "match_options" */
 ["match_options_aggregate"]: {
@@ -208017,7 +208568,8 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** Boolean expression to filter rows from the table "match_options". All fields are combined with a logical 'AND'. */
 ["match_options_bool_exp"]: {
@@ -208056,7 +208608,8 @@ export type GraphQLTypes = {
 	tournament_bracket?: GraphQLTypes["tournament_brackets_bool_exp"] | undefined | null,
 	tournament_stage?: GraphQLTypes["tournament_stages_bool_exp"] | undefined | null,
 	tv_delay?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
-	type?: GraphQLTypes["e_match_types_enum_comparison_exp"] | undefined | null
+	type?: GraphQLTypes["e_match_types_enum_comparison_exp"] | undefined | null,
+	veto_pick_timeout?: GraphQLTypes["Int_comparison_exp"] | undefined | null
 };
 	/** unique or primary key constraints on table "match_options" */
 ["match_options_constraint"]: match_options_constraint;
@@ -208068,7 +208621,8 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** input type for inserting data into table "match_options" */
 ["match_options_insert_input"]: {
@@ -208102,7 +208656,8 @@ export type GraphQLTypes = {
 	tournament_bracket?: GraphQLTypes["tournament_brackets_obj_rel_insert_input"] | undefined | null,
 	tournament_stage?: GraphQLTypes["tournament_stages_obj_rel_insert_input"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: GraphQLTypes["e_match_types_enum"] | undefined | null
+	type?: GraphQLTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate max on columns */
 ["match_options_max_fields"]: {
@@ -208117,7 +208672,8 @@ export type GraphQLTypes = {
 	number_of_substitutes?: number | undefined | null,
 	regions?: Array<string> | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate min on columns */
 ["match_options_min_fields"]: {
@@ -208132,7 +208688,8 @@ export type GraphQLTypes = {
 	number_of_substitutes?: number | undefined | null,
 	regions?: Array<string> | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** response of any mutation on the table "match_options" */
 ["match_options_mutation_response"]: {
@@ -208187,7 +208744,8 @@ export type GraphQLTypes = {
 	tournament_bracket?: GraphQLTypes["tournament_brackets_order_by"] | undefined | null,
 	tournament_stage?: GraphQLTypes["tournament_stages_order_by"] | undefined | null,
 	tv_delay?: GraphQLTypes["order_by"] | undefined | null,
-	type?: GraphQLTypes["order_by"] | undefined | null
+	type?: GraphQLTypes["order_by"] | undefined | null,
+	veto_pick_timeout?: GraphQLTypes["order_by"] | undefined | null
 };
 	/** primary key columns input for table: match_options */
 ["match_options_pk_columns_input"]: {
@@ -208222,7 +208780,8 @@ export type GraphQLTypes = {
 	tech_timeout_setting?: GraphQLTypes["e_timeout_settings_enum"] | undefined | null,
 	timeout_setting?: GraphQLTypes["e_timeout_settings_enum"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: GraphQLTypes["e_match_types_enum"] | undefined | null
+	type?: GraphQLTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate stddev on columns */
 ["match_options_stddev_fields"]: {
@@ -208233,7 +208792,8 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate stddev_pop on columns */
 ["match_options_stddev_pop_fields"]: {
@@ -208244,7 +208804,8 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate stddev_samp on columns */
 ["match_options_stddev_samp_fields"]: {
@@ -208255,7 +208816,8 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** Streaming cursor of the table "match_options" */
 ["match_options_stream_cursor_input"]: {
@@ -208291,7 +208853,8 @@ export type GraphQLTypes = {
 	tech_timeout_setting?: GraphQLTypes["e_timeout_settings_enum"] | undefined | null,
 	timeout_setting?: GraphQLTypes["e_timeout_settings_enum"] | undefined | null,
 	tv_delay?: number | undefined | null,
-	type?: GraphQLTypes["e_match_types_enum"] | undefined | null
+	type?: GraphQLTypes["e_match_types_enum"] | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate sum on columns */
 ["match_options_sum_fields"]: {
@@ -208302,7 +208865,8 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** update columns of table "match_options" */
 ["match_options_update_column"]: match_options_update_column;
@@ -208323,7 +208887,8 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate var_samp on columns */
 ["match_options_var_samp_fields"]: {
@@ -208334,7 +208899,8 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** aggregate variance on columns */
 ["match_options_variance_fields"]: {
@@ -208345,11 +208911,13 @@ export type GraphQLTypes = {
 	mr?: number | undefined | null,
 	number_of_substitutes?: number | undefined | null,
 	round_restart_delay?: number | undefined | null,
-	tv_delay?: number | undefined | null
+	tv_delay?: number | undefined | null,
+	veto_pick_timeout?: number | undefined | null
 };
 	/** columns and relationships of "match_region_veto_picks" */
 ["match_region_veto_picks"]: {
 	__typename: "match_region_veto_picks",
+	auto_picked: boolean,
 	created_at: GraphQLTypes["timestamptz"],
 	id: GraphQLTypes["uuid"],
 	/** An object relationship */
@@ -208368,7 +208936,21 @@ export type GraphQLTypes = {
 	nodes: Array<GraphQLTypes["match_region_veto_picks"]>
 };
 	["match_region_veto_picks_aggregate_bool_exp"]: {
-		count?: GraphQLTypes["match_region_veto_picks_aggregate_bool_exp_count"] | undefined | null
+		bool_and?: GraphQLTypes["match_region_veto_picks_aggregate_bool_exp_bool_and"] | undefined | null,
+	bool_or?: GraphQLTypes["match_region_veto_picks_aggregate_bool_exp_bool_or"] | undefined | null,
+	count?: GraphQLTypes["match_region_veto_picks_aggregate_bool_exp_count"] | undefined | null
+};
+	["match_region_veto_picks_aggregate_bool_exp_bool_and"]: {
+		arguments: GraphQLTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: GraphQLTypes["match_region_veto_picks_bool_exp"] | undefined | null,
+	predicate: GraphQLTypes["Boolean_comparison_exp"]
+};
+	["match_region_veto_picks_aggregate_bool_exp_bool_or"]: {
+		arguments: GraphQLTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"],
+	distinct?: boolean | undefined | null,
+	filter?: GraphQLTypes["match_region_veto_picks_bool_exp"] | undefined | null,
+	predicate: GraphQLTypes["Boolean_comparison_exp"]
 };
 	["match_region_veto_picks_aggregate_bool_exp_count"]: {
 		arguments?: Array<GraphQLTypes["match_region_veto_picks_select_column"]> | undefined | null,
@@ -208400,6 +208982,7 @@ export type GraphQLTypes = {
 		_and?: Array<GraphQLTypes["match_region_veto_picks_bool_exp"]> | undefined | null,
 	_not?: GraphQLTypes["match_region_veto_picks_bool_exp"] | undefined | null,
 	_or?: Array<GraphQLTypes["match_region_veto_picks_bool_exp"]> | undefined | null,
+	auto_picked?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	created_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined | null,
 	id?: GraphQLTypes["uuid_comparison_exp"] | undefined | null,
 	match?: GraphQLTypes["matches_bool_exp"] | undefined | null,
@@ -208413,7 +208996,8 @@ export type GraphQLTypes = {
 ["match_region_veto_picks_constraint"]: match_region_veto_picks_constraint;
 	/** input type for inserting data into table "match_region_veto_picks" */
 ["match_region_veto_picks_insert_input"]: {
-		created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+		auto_picked?: boolean | undefined | null,
+	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
 	match?: GraphQLTypes["matches_obj_rel_insert_input"] | undefined | null,
 	match_id?: GraphQLTypes["uuid"] | undefined | null,
@@ -208472,7 +209056,8 @@ export type GraphQLTypes = {
 };
 	/** Ordering options when selecting data from "match_region_veto_picks". */
 ["match_region_veto_picks_order_by"]: {
-		created_at?: GraphQLTypes["order_by"] | undefined | null,
+		auto_picked?: GraphQLTypes["order_by"] | undefined | null,
+	created_at?: GraphQLTypes["order_by"] | undefined | null,
 	id?: GraphQLTypes["order_by"] | undefined | null,
 	match?: GraphQLTypes["matches_order_by"] | undefined | null,
 	match_id?: GraphQLTypes["order_by"] | undefined | null,
@@ -208487,9 +209072,14 @@ export type GraphQLTypes = {
 };
 	/** select columns of table "match_region_veto_picks" */
 ["match_region_veto_picks_select_column"]: match_region_veto_picks_select_column;
+	/** select "match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_region_veto_picks" */
+["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]: match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns;
+	/** select "match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_region_veto_picks" */
+["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]: match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns;
 	/** input type for updating data in table "match_region_veto_picks" */
 ["match_region_veto_picks_set_input"]: {
-		created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+		auto_picked?: boolean | undefined | null,
+	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
 	match_id?: GraphQLTypes["uuid"] | undefined | null,
 	match_lineup_id?: GraphQLTypes["uuid"] | undefined | null,
@@ -208505,7 +209095,8 @@ export type GraphQLTypes = {
 };
 	/** Initial value of the column from where the streaming should start */
 ["match_region_veto_picks_stream_cursor_value_input"]: {
-		created_at?: GraphQLTypes["timestamptz"] | undefined | null,
+		auto_picked?: boolean | undefined | null,
+	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	id?: GraphQLTypes["uuid"] | undefined | null,
 	match_id?: GraphQLTypes["uuid"] | undefined | null,
 	match_lineup_id?: GraphQLTypes["uuid"] | undefined | null,
@@ -209186,6 +209777,7 @@ export type GraphQLTypes = {
 	tournament_brackets_aggregate: GraphQLTypes["tournament_brackets_aggregate"],
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?: string | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** An object relationship */
 	winner?: GraphQLTypes["match_lineups"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["uuid"] | undefined | null
@@ -209351,6 +209943,7 @@ export type GraphQLTypes = {
 	tournament_brackets?: GraphQLTypes["tournament_brackets_bool_exp"] | undefined | null,
 	tournament_brackets_aggregate?: GraphQLTypes["tournament_brackets_aggregate_bool_exp"] | undefined | null,
 	tv_connection_string?: GraphQLTypes["String_comparison_exp"] | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined | null,
 	winner?: GraphQLTypes["match_lineups_bool_exp"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["uuid_comparison_exp"] | undefined | null
 };
@@ -209405,6 +209998,7 @@ export type GraphQLTypes = {
 	status?: GraphQLTypes["e_match_status_enum"] | undefined | null,
 	streams?: GraphQLTypes["match_streams_arr_rel_insert_input"] | undefined | null,
 	tournament_brackets?: GraphQLTypes["tournament_brackets_arr_rel_insert_input"] | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	winner?: GraphQLTypes["match_lineups_obj_rel_insert_input"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["uuid"] | undefined | null
 };
@@ -209456,6 +210050,7 @@ export type GraphQLTypes = {
 	started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?: string | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["uuid"] | undefined | null
 };
 	/** order by max() on columns of table "matches" */
@@ -209479,6 +210074,7 @@ export type GraphQLTypes = {
 	share_code?: GraphQLTypes["order_by"] | undefined | null,
 	source?: GraphQLTypes["order_by"] | undefined | null,
 	started_at?: GraphQLTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["order_by"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["order_by"] | undefined | null
 };
 	/** aggregate min on columns */
@@ -209529,6 +210125,7 @@ export type GraphQLTypes = {
 	started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "get_match_tv_connection_string" */
 	tv_connection_string?: string | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["uuid"] | undefined | null
 };
 	/** order by min() on columns of table "matches" */
@@ -209552,6 +210149,7 @@ export type GraphQLTypes = {
 	share_code?: GraphQLTypes["order_by"] | undefined | null,
 	source?: GraphQLTypes["order_by"] | undefined | null,
 	started_at?: GraphQLTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["order_by"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["order_by"] | undefined | null
 };
 	/** response of any mutation on the table "matches" */
@@ -209652,6 +210250,7 @@ export type GraphQLTypes = {
 	teams_aggregate?: GraphQLTypes["teams_aggregate_order_by"] | undefined | null,
 	tournament_brackets_aggregate?: GraphQLTypes["tournament_brackets_aggregate_order_by"] | undefined | null,
 	tv_connection_string?: GraphQLTypes["order_by"] | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["order_by"] | undefined | null,
 	winner?: GraphQLTypes["match_lineups_order_by"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["order_by"] | undefined | null
 };
@@ -209682,6 +210281,7 @@ export type GraphQLTypes = {
 	source?: string | undefined | null,
 	started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	status?: GraphQLTypes["e_match_status_enum"] | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["uuid"] | undefined | null
 };
 	/** aggregate stddev on columns */
@@ -209752,6 +210352,7 @@ export type GraphQLTypes = {
 	source?: string | undefined | null,
 	started_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	status?: GraphQLTypes["e_match_status_enum"] | undefined | null,
+	veto_pick_expires_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	winning_lineup_id?: GraphQLTypes["uuid"] | undefined | null
 };
 	/** aggregate sum on columns */
@@ -210607,6 +211208,7 @@ export type GraphQLTypes = {
 	/** delete single row from the table: "v_team_stage_results" */
 	delete_v_team_stage_results_by_pk?: GraphQLTypes["v_team_stage_results"] | undefined | null,
 	denyInvite?: GraphQLTypes["SuccessOutput"] | undefined | null,
+	denyNameChange?: GraphQLTypes["SuccessOutput"] | undefined | null,
 	forfeitMatch?: GraphQLTypes["SuccessOutput"] | undefined | null,
 	/** Live pod GSI snapshot — slots, sides, alive/dead. Drives the stream-deck. */
 	getLiveStreamSpecState?: GraphQLTypes["LiveStreamSpecState"] | undefined | null,
@@ -226077,6 +226679,8 @@ export type GraphQLTypes = {
 	awards: Array<GraphQLTypes["award_recipients"]>,
 	/** An aggregate relationship */
 	awards_aggregate: GraphQLTypes["award_recipients_aggregate"],
+	/** A computed field, executes function "banned_until" */
+	banned_until?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** An array relationship */
 	coach_lineups: Array<GraphQLTypes["match_lineups"]>,
 	/** An aggregate relationship */
@@ -226137,6 +226741,8 @@ export type GraphQLTypes = {
 	invited_players: Array<GraphQLTypes["team_invites"]>,
 	/** An aggregate relationship */
 	invited_players_aggregate: GraphQLTypes["team_invites_aggregate"],
+	/** A computed field, executes function "is_admin_sanctioned" */
+	is_admin_sanctioned?: boolean | undefined | null,
 	/** A computed field, executes function "is_banned" */
 	is_banned?: boolean | undefined | null,
 	/** A computed field, executes function "is_gagged" */
@@ -226149,6 +226755,8 @@ export type GraphQLTypes = {
 	is_in_lobby?: boolean | undefined | null,
 	/** A computed field, executes function "is_muted" */
 	is_muted?: boolean | undefined | null,
+	/** A computed field, executes function "is_registered" */
+	is_registered?: boolean | undefined | null,
 	/** An array relationship */
 	kills: Array<GraphQLTypes["player_kills"]>,
 	/** An aggregate relationship */
@@ -226351,6 +226959,7 @@ export type GraphQLTypes = {
 	avatar_url?: GraphQLTypes["String_comparison_exp"] | undefined | null,
 	awards?: GraphQLTypes["award_recipients_bool_exp"] | undefined | null,
 	awards_aggregate?: GraphQLTypes["award_recipients_aggregate_bool_exp"] | undefined | null,
+	banned_until?: GraphQLTypes["timestamptz_comparison_exp"] | undefined | null,
 	coach_lineups?: GraphQLTypes["match_lineups_bool_exp"] | undefined | null,
 	coach_lineups_aggregate?: GraphQLTypes["match_lineups_aggregate_bool_exp"] | undefined | null,
 	country?: GraphQLTypes["String_comparison_exp"] | undefined | null,
@@ -226387,12 +226996,14 @@ export type GraphQLTypes = {
 	game_ban_count?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	invited_players?: GraphQLTypes["team_invites_bool_exp"] | undefined | null,
 	invited_players_aggregate?: GraphQLTypes["team_invites_aggregate_bool_exp"] | undefined | null,
+	is_admin_sanctioned?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	is_banned?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	is_gagged?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_another_match?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_draft?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	is_in_lobby?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	is_muted?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
+	is_registered?: GraphQLTypes["Boolean_comparison_exp"] | undefined | null,
 	kills?: GraphQLTypes["player_kills_bool_exp"] | undefined | null,
 	kills_aggregate?: GraphQLTypes["player_kills_aggregate_bool_exp"] | undefined | null,
 	kills_by_weapons?: GraphQLTypes["player_kills_by_weapon_bool_exp"] | undefined | null,
@@ -226556,6 +227167,8 @@ export type GraphQLTypes = {
 ["players_max_fields"]: {
 	__typename: "players_max_fields",
 	avatar_url?: string | undefined | null,
+	/** A computed field, executes function "banned_until" */
+	banned_until?: GraphQLTypes["timestamptz"] | undefined | null,
 	country?: string | undefined | null,
 	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "get_player_current_lobby_id" */
@@ -226606,6 +227219,8 @@ export type GraphQLTypes = {
 ["players_min_fields"]: {
 	__typename: "players_min_fields",
 	avatar_url?: string | undefined | null,
+	/** A computed field, executes function "banned_until" */
+	banned_until?: GraphQLTypes["timestamptz"] | undefined | null,
 	country?: string | undefined | null,
 	created_at?: GraphQLTypes["timestamptz"] | undefined | null,
 	/** A computed field, executes function "get_player_current_lobby_id" */
@@ -226680,6 +227295,7 @@ export type GraphQLTypes = {
 	assited_by_players_aggregate?: GraphQLTypes["player_assists_aggregate_order_by"] | undefined | null,
 	avatar_url?: GraphQLTypes["order_by"] | undefined | null,
 	awards_aggregate?: GraphQLTypes["award_recipients_aggregate_order_by"] | undefined | null,
+	banned_until?: GraphQLTypes["order_by"] | undefined | null,
 	coach_lineups_aggregate?: GraphQLTypes["match_lineups_aggregate_order_by"] | undefined | null,
 	country?: GraphQLTypes["order_by"] | undefined | null,
 	created_at?: GraphQLTypes["order_by"] | undefined | null,
@@ -226705,12 +227321,14 @@ export type GraphQLTypes = {
 	friends_aggregate?: GraphQLTypes["my_friends_aggregate_order_by"] | undefined | null,
 	game_ban_count?: GraphQLTypes["order_by"] | undefined | null,
 	invited_players_aggregate?: GraphQLTypes["team_invites_aggregate_order_by"] | undefined | null,
+	is_admin_sanctioned?: GraphQLTypes["order_by"] | undefined | null,
 	is_banned?: GraphQLTypes["order_by"] | undefined | null,
 	is_gagged?: GraphQLTypes["order_by"] | undefined | null,
 	is_in_another_match?: GraphQLTypes["order_by"] | undefined | null,
 	is_in_draft?: GraphQLTypes["order_by"] | undefined | null,
 	is_in_lobby?: GraphQLTypes["order_by"] | undefined | null,
 	is_muted?: GraphQLTypes["order_by"] | undefined | null,
+	is_registered?: GraphQLTypes["order_by"] | undefined | null,
 	kills_aggregate?: GraphQLTypes["player_kills_aggregate_order_by"] | undefined | null,
 	kills_by_weapons_aggregate?: GraphQLTypes["player_kills_by_weapon_aggregate_order_by"] | undefined | null,
 	language?: GraphQLTypes["order_by"] | undefined | null,
@@ -245566,10 +246184,12 @@ export type GraphQLTypes = {
 	/** columns and relationships of "v_team_ranks" */
 ["v_team_ranks"]: {
 	__typename: "v_team_ranks",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: GraphQLTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: GraphQLTypes["bigint"] | undefined | null,
@@ -245601,10 +246221,12 @@ export type GraphQLTypes = {
 	/** aggregate avg on columns */
 ["v_team_ranks_avg_fields"]: {
 	__typename: "v_team_ranks_avg_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -245614,10 +246236,12 @@ export type GraphQLTypes = {
 		_and?: Array<GraphQLTypes["v_team_ranks_bool_exp"]> | undefined | null,
 	_not?: GraphQLTypes["v_team_ranks_bool_exp"] | undefined | null,
 	_or?: Array<GraphQLTypes["v_team_ranks_bool_exp"]> | undefined | null,
+	avg_duel_elo?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	avg_elo?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	avg_faceit_elo?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	avg_faceit_level?: GraphQLTypes["float8_comparison_exp"] | undefined | null,
 	avg_premier?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
+	avg_wingman_elo?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	max_elo?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	min_elo?: GraphQLTypes["Int_comparison_exp"] | undefined | null,
 	roster_size?: GraphQLTypes["bigint_comparison_exp"] | undefined | null,
@@ -245626,10 +246250,12 @@ export type GraphQLTypes = {
 };
 	/** input type for inserting data into table "v_team_ranks" */
 ["v_team_ranks_insert_input"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: GraphQLTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: GraphQLTypes["bigint"] | undefined | null,
@@ -245639,10 +246265,12 @@ export type GraphQLTypes = {
 	/** aggregate max on columns */
 ["v_team_ranks_max_fields"]: {
 	__typename: "v_team_ranks_max_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: GraphQLTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: GraphQLTypes["bigint"] | undefined | null,
@@ -245651,10 +246279,12 @@ export type GraphQLTypes = {
 	/** aggregate min on columns */
 ["v_team_ranks_min_fields"]: {
 	__typename: "v_team_ranks_min_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: GraphQLTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: GraphQLTypes["bigint"] | undefined | null,
@@ -245666,10 +246296,12 @@ export type GraphQLTypes = {
 };
 	/** Ordering options when selecting data from "v_team_ranks". */
 ["v_team_ranks_order_by"]: {
-		avg_elo?: GraphQLTypes["order_by"] | undefined | null,
+		avg_duel_elo?: GraphQLTypes["order_by"] | undefined | null,
+	avg_elo?: GraphQLTypes["order_by"] | undefined | null,
 	avg_faceit_elo?: GraphQLTypes["order_by"] | undefined | null,
 	avg_faceit_level?: GraphQLTypes["order_by"] | undefined | null,
 	avg_premier?: GraphQLTypes["order_by"] | undefined | null,
+	avg_wingman_elo?: GraphQLTypes["order_by"] | undefined | null,
 	max_elo?: GraphQLTypes["order_by"] | undefined | null,
 	min_elo?: GraphQLTypes["order_by"] | undefined | null,
 	roster_size?: GraphQLTypes["order_by"] | undefined | null,
@@ -245681,10 +246313,12 @@ export type GraphQLTypes = {
 	/** aggregate stddev on columns */
 ["v_team_ranks_stddev_fields"]: {
 	__typename: "v_team_ranks_stddev_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -245692,10 +246326,12 @@ export type GraphQLTypes = {
 	/** aggregate stddev_pop on columns */
 ["v_team_ranks_stddev_pop_fields"]: {
 	__typename: "v_team_ranks_stddev_pop_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -245703,10 +246339,12 @@ export type GraphQLTypes = {
 	/** aggregate stddev_samp on columns */
 ["v_team_ranks_stddev_samp_fields"]: {
 	__typename: "v_team_ranks_stddev_samp_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -245720,10 +246358,12 @@ export type GraphQLTypes = {
 };
 	/** Initial value of the column from where the streaming should start */
 ["v_team_ranks_stream_cursor_value_input"]: {
-		avg_elo?: number | undefined | null,
+		avg_duel_elo?: number | undefined | null,
+	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: GraphQLTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: GraphQLTypes["bigint"] | undefined | null,
@@ -245732,10 +246372,12 @@ export type GraphQLTypes = {
 	/** aggregate sum on columns */
 ["v_team_ranks_sum_fields"]: {
 	__typename: "v_team_ranks_sum_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: GraphQLTypes["float8"] | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: GraphQLTypes["bigint"] | undefined | null
@@ -245743,10 +246385,12 @@ export type GraphQLTypes = {
 	/** aggregate var_pop on columns */
 ["v_team_ranks_var_pop_fields"]: {
 	__typename: "v_team_ranks_var_pop_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -245754,10 +246398,12 @@ export type GraphQLTypes = {
 	/** aggregate var_samp on columns */
 ["v_team_ranks_var_samp_fields"]: {
 	__typename: "v_team_ranks_var_samp_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -245765,10 +246411,12 @@ export type GraphQLTypes = {
 	/** aggregate variance on columns */
 ["v_team_ranks_variance_fields"]: {
 	__typename: "v_team_ranks_variance_fields",
+	avg_duel_elo?: number | undefined | null,
 	avg_elo?: number | undefined | null,
 	avg_faceit_elo?: number | undefined | null,
 	avg_faceit_level?: number | undefined | null,
 	avg_premier?: number | undefined | null,
+	avg_wingman_elo?: number | undefined | null,
 	max_elo?: number | undefined | null,
 	min_elo?: number | undefined | null,
 	roster_size?: number | undefined | null
@@ -247719,12 +248367,14 @@ export enum abandoned_matches_constraint {
 export enum abandoned_matches_select_column {
 	abandoned_at = "abandoned_at",
 	id = "id",
+	match_id = "match_id",
 	steam_id = "steam_id"
 }
 /** update columns of table "abandoned_matches" */
 export enum abandoned_matches_update_column {
 	abandoned_at = "abandoned_at",
 	id = "id",
+	match_id = "match_id",
 	steam_id = "steam_id"
 }
 /** unique or primary key constraints on table "api_keys" */
@@ -248645,9 +249295,12 @@ export enum e_notification_types_enum {
 	LeagueProposalReceived = "LeagueProposalReceived",
 	LeagueRegistrationDecision = "LeagueRegistrationDecision",
 	LeagueRosterUndersized = "LeagueRosterUndersized",
+	MatchAbandoned = "MatchAbandoned",
 	MatchImported = "MatchImported",
 	MatchStatusChange = "MatchStatusChange",
 	MatchSupport = "MatchSupport",
+	NameChangeApproved = "NameChangeApproved",
+	NameChangeDenied = "NameChangeDenied",
 	NameChangeRequest = "NameChangeRequest",
 	PlayerReindex = "PlayerReindex",
 	PlayerSanctioned = "PlayerSanctioned",
@@ -249386,6 +250039,7 @@ export enum leaderboard_entries_select_column {
 	matches_played = "matches_played",
 	player_avatar_url = "player_avatar_url",
 	player_country = "player_country",
+	player_custom_avatar_url = "player_custom_avatar_url",
 	player_name = "player_name",
 	player_steam_id = "player_steam_id",
 	secondary_value = "secondary_value",
@@ -249885,6 +250539,7 @@ export enum match_lineup_players_select_column {
 	checked_in = "checked_in",
 	discord_id = "discord_id",
 	id = "id",
+	is_connected = "is_connected",
 	match_lineup_id = "match_lineup_id",
 	party_id = "party_id",
 	party_source = "party_source",
@@ -249894,12 +250549,14 @@ export enum match_lineup_players_select_column {
 /** select "match_lineup_players_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_lineup_players" */
 export enum match_lineup_players_select_column_match_lineup_players_aggregate_bool_exp_bool_and_arguments_columns {
 	captain = "captain",
-	checked_in = "checked_in"
+	checked_in = "checked_in",
+	is_connected = "is_connected"
 }
 /** select "match_lineup_players_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_lineup_players" */
 export enum match_lineup_players_select_column_match_lineup_players_aggregate_bool_exp_bool_or_arguments_columns {
 	captain = "captain",
-	checked_in = "checked_in"
+	checked_in = "checked_in",
+	is_connected = "is_connected"
 }
 /** update columns of table "match_lineup_players" */
 export enum match_lineup_players_update_column {
@@ -249907,6 +250564,7 @@ export enum match_lineup_players_update_column {
 	checked_in = "checked_in",
 	discord_id = "discord_id",
 	id = "id",
+	is_connected = "is_connected",
 	match_lineup_id = "match_lineup_id",
 	party_id = "party_id",
 	party_source = "party_source",
@@ -250044,6 +250702,7 @@ export enum match_map_veto_picks_constraint {
 }
 /** select columns of table "match_map_veto_picks" */
 export enum match_map_veto_picks_select_column {
+	auto_picked = "auto_picked",
 	created_at = "created_at",
 	id = "id",
 	map_id = "map_id",
@@ -250052,8 +250711,17 @@ export enum match_map_veto_picks_select_column {
 	side = "side",
 	type = "type"
 }
+/** select "match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_map_veto_picks" */
+export enum match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns {
+	auto_picked = "auto_picked"
+}
+/** select "match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_map_veto_picks" */
+export enum match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns {
+	auto_picked = "auto_picked"
+}
 /** update columns of table "match_map_veto_picks" */
 export enum match_map_veto_picks_update_column {
+	auto_picked = "auto_picked",
 	created_at = "created_at",
 	id = "id",
 	map_id = "map_id",
@@ -250071,6 +250739,7 @@ export enum match_maps_constraint {
 export enum match_maps_select_column {
 	clips_count = "clips_count",
 	created_at = "created_at",
+	demo_processing_started_at = "demo_processing_started_at",
 	ended_at = "ended_at",
 	id = "id",
 	latest_clip_at = "latest_clip_at",
@@ -250091,6 +250760,7 @@ export enum match_maps_select_column {
 export enum match_maps_update_column {
 	clips_count = "clips_count",
 	created_at = "created_at",
+	demo_processing_started_at = "demo_processing_started_at",
 	ended_at = "ended_at",
 	id = "id",
 	latest_clip_at = "latest_clip_at",
@@ -250138,7 +250808,8 @@ export enum match_options_select_column {
 	tech_timeout_setting = "tech_timeout_setting",
 	timeout_setting = "timeout_setting",
 	tv_delay = "tv_delay",
-	type = "type"
+	type = "type",
+	veto_pick_timeout = "veto_pick_timeout"
 }
 /** update columns of table "match_options" */
 export enum match_options_update_column {
@@ -250167,7 +250838,8 @@ export enum match_options_update_column {
 	tech_timeout_setting = "tech_timeout_setting",
 	timeout_setting = "timeout_setting",
 	tv_delay = "tv_delay",
-	type = "type"
+	type = "type",
+	veto_pick_timeout = "veto_pick_timeout"
 }
 /** unique or primary key constraints on table "match_region_veto_picks" */
 export enum match_region_veto_picks_constraint {
@@ -250176,6 +250848,7 @@ export enum match_region_veto_picks_constraint {
 }
 /** select columns of table "match_region_veto_picks" */
 export enum match_region_veto_picks_select_column {
+	auto_picked = "auto_picked",
 	created_at = "created_at",
 	id = "id",
 	match_id = "match_id",
@@ -250183,8 +250856,17 @@ export enum match_region_veto_picks_select_column {
 	region = "region",
 	type = "type"
 }
+/** select "match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns" columns of table "match_region_veto_picks" */
+export enum match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns {
+	auto_picked = "auto_picked"
+}
+/** select "match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns" columns of table "match_region_veto_picks" */
+export enum match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns {
+	auto_picked = "auto_picked"
+}
 /** update columns of table "match_region_veto_picks" */
 export enum match_region_veto_picks_update_column {
+	auto_picked = "auto_picked",
 	created_at = "created_at",
 	id = "id",
 	match_id = "match_id",
@@ -250290,6 +250972,7 @@ export enum matches_select_column {
 	source = "source",
 	started_at = "started_at",
 	status = "status",
+	veto_pick_expires_at = "veto_pick_expires_at",
 	winning_lineup_id = "winning_lineup_id"
 }
 /** update columns of table "matches" */
@@ -250313,6 +250996,7 @@ export enum matches_update_column {
 	source = "source",
 	started_at = "started_at",
 	status = "status",
+	veto_pick_expires_at = "veto_pick_expires_at",
 	winning_lineup_id = "winning_lineup_id"
 }
 /** unique or primary key constraints on table "migration_hashes.hashes" */
@@ -253046,10 +253730,12 @@ export enum v_steam_account_pool_status_select_column {
 }
 /** select columns of table "v_team_ranks" */
 export enum v_team_ranks_select_column {
+	avg_duel_elo = "avg_duel_elo",
 	avg_elo = "avg_elo",
 	avg_faceit_elo = "avg_faceit_elo",
 	avg_faceit_level = "avg_faceit_level",
 	avg_premier = "avg_premier",
+	avg_wingman_elo = "avg_wingman_elo",
 	max_elo = "max_elo",
 	min_elo = "min_elo",
 	roster_size = "roster_size",
@@ -254943,6 +255629,8 @@ type ZEUS_VARIABLES = {
 	["match_map_rounds_var_samp_order_by"]: ValueTypes["match_map_rounds_var_samp_order_by"];
 	["match_map_rounds_variance_order_by"]: ValueTypes["match_map_rounds_variance_order_by"];
 	["match_map_veto_picks_aggregate_bool_exp"]: ValueTypes["match_map_veto_picks_aggregate_bool_exp"];
+	["match_map_veto_picks_aggregate_bool_exp_bool_and"]: ValueTypes["match_map_veto_picks_aggregate_bool_exp_bool_and"];
+	["match_map_veto_picks_aggregate_bool_exp_bool_or"]: ValueTypes["match_map_veto_picks_aggregate_bool_exp_bool_or"];
 	["match_map_veto_picks_aggregate_bool_exp_count"]: ValueTypes["match_map_veto_picks_aggregate_bool_exp_count"];
 	["match_map_veto_picks_aggregate_order_by"]: ValueTypes["match_map_veto_picks_aggregate_order_by"];
 	["match_map_veto_picks_arr_rel_insert_input"]: ValueTypes["match_map_veto_picks_arr_rel_insert_input"];
@@ -254955,6 +255643,8 @@ type ZEUS_VARIABLES = {
 	["match_map_veto_picks_order_by"]: ValueTypes["match_map_veto_picks_order_by"];
 	["match_map_veto_picks_pk_columns_input"]: ValueTypes["match_map_veto_picks_pk_columns_input"];
 	["match_map_veto_picks_select_column"]: ValueTypes["match_map_veto_picks_select_column"];
+	["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]: ValueTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"];
+	["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]: ValueTypes["match_map_veto_picks_select_column_match_map_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"];
 	["match_map_veto_picks_set_input"]: ValueTypes["match_map_veto_picks_set_input"];
 	["match_map_veto_picks_stream_cursor_input"]: ValueTypes["match_map_veto_picks_stream_cursor_input"];
 	["match_map_veto_picks_stream_cursor_value_input"]: ValueTypes["match_map_veto_picks_stream_cursor_value_input"];
@@ -255003,6 +255693,8 @@ type ZEUS_VARIABLES = {
 	["match_options_update_column"]: ValueTypes["match_options_update_column"];
 	["match_options_updates"]: ValueTypes["match_options_updates"];
 	["match_region_veto_picks_aggregate_bool_exp"]: ValueTypes["match_region_veto_picks_aggregate_bool_exp"];
+	["match_region_veto_picks_aggregate_bool_exp_bool_and"]: ValueTypes["match_region_veto_picks_aggregate_bool_exp_bool_and"];
+	["match_region_veto_picks_aggregate_bool_exp_bool_or"]: ValueTypes["match_region_veto_picks_aggregate_bool_exp_bool_or"];
 	["match_region_veto_picks_aggregate_bool_exp_count"]: ValueTypes["match_region_veto_picks_aggregate_bool_exp_count"];
 	["match_region_veto_picks_aggregate_order_by"]: ValueTypes["match_region_veto_picks_aggregate_order_by"];
 	["match_region_veto_picks_arr_rel_insert_input"]: ValueTypes["match_region_veto_picks_arr_rel_insert_input"];
@@ -255015,6 +255707,8 @@ type ZEUS_VARIABLES = {
 	["match_region_veto_picks_order_by"]: ValueTypes["match_region_veto_picks_order_by"];
 	["match_region_veto_picks_pk_columns_input"]: ValueTypes["match_region_veto_picks_pk_columns_input"];
 	["match_region_veto_picks_select_column"]: ValueTypes["match_region_veto_picks_select_column"];
+	["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"]: ValueTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_and_arguments_columns"];
+	["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"]: ValueTypes["match_region_veto_picks_select_column_match_region_veto_picks_aggregate_bool_exp_bool_or_arguments_columns"];
 	["match_region_veto_picks_set_input"]: ValueTypes["match_region_veto_picks_set_input"];
 	["match_region_veto_picks_stream_cursor_input"]: ValueTypes["match_region_veto_picks_stream_cursor_input"];
 	["match_region_veto_picks_stream_cursor_value_input"]: ValueTypes["match_region_veto_picks_stream_cursor_value_input"];

--- a/graphql/meGraphql.ts
+++ b/graphql/meGraphql.ts
@@ -7,6 +7,8 @@ export const meFields = Selector("players")({
   role: true,
   profile_url: true,
   matchmaking_cooldown: true,
+  // Null while banned means the ban is permanent -- there is no date to show.
+  banned_until: true,
   current_lobby_id: true,
   language: true,
   country: true,

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -5700,7 +5700,7 @@
     "banned_until": "You are banned from matchmaking until {time}",
     "confirm_selection": "Join Queue",
     "in_queue": "in queue",
-    "temp_banned": "You are temporarily banned from matchmaking until {time}",
+    "temp_banned": "You are temporarily banned from matchmaking",
     "settings_section": {
       "toggle": "Adjust Settings"
     },
@@ -5709,7 +5709,8 @@
     "party_size": {
       "unavailable": "Party of {size} can't queue this mode",
       "requirement": "Queue with {half} or fewer, or exactly {full} players"
-    }
+    },
+    "temp_banned_until": "You are temporarily banned from matchmaking until {time}"
   },
   "game_server": {
     "lan_ip": "LAN IP",
@@ -5865,7 +5866,9 @@
       "no_access": "You do not have access to this page.",
       "sidebar_hint": "Chat is available in the right sidebar under the Chats tab."
     },
-    "in_chat": "in chat"
+    "in_chat": "in chat",
+    "everyone": "Everyone",
+    "your_team": "Your team"
   },
   "charts": {
     "usage": "Usage",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2981,6 +2981,12 @@
         "Support": "Support",
         "Rifler": "Rifler"
       },
+      "sources": {
+        "overall": "All Sources",
+        "matchmaking": "Matchmaking",
+        "tournament": "Tournament",
+        "league": "League"
+      },
       "columns": {
         "rank": "#",
         "matches": "Matches"
@@ -4850,6 +4856,7 @@
     },
     "winner": {
       "set": "Set Match Winner",
+      "set_failed": "Could not set match winner",
       "select_lineup": "Select Lineup"
     },
     "map_winner": {
@@ -4902,6 +4909,7 @@
       "picked": "Picked"
     },
     "auto_canceling": "Auto Canceling",
+    "demo_processing": "Processing demo",
     "actions": {
       "call_support": "Call for Support",
       "start_veto": "Start Veto",
@@ -5688,9 +5696,10 @@
       "title": "Others"
     },
     "banned": "You are banned from matchmaking",
+    "banned_until": "You are banned from matchmaking until {time}",
     "confirm_selection": "Join Queue",
     "in_queue": "in queue",
-    "temp_banned": "You are temporarily banned from matchmaking",
+    "temp_banned": "You are temporarily banned from matchmaking until {time}",
     "settings_section": {
       "toggle": "Adjust Settings"
     },
@@ -7190,5 +7199,9 @@
   "awards_manage_form": {
     "team": "Team",
     "player": "Player"
+  },
+  "search": {
+    "unregistered": "Not registered",
+    "registered_only": "Registered only"
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -5360,7 +5360,8 @@
       "rcon_unavailable": "RCON unavailable",
       "not_controllable": "Match is not in a controllable state.",
       "veto_override": "Veto Override"
-    }
+    },
+    "demo_processing_hint": "The match demo is uploading from the game server. Stats, the 2D replay and highlights land once it finishes."
   },
   "ui": {
     "tooltips": {
@@ -7202,6 +7203,7 @@
   },
   "search": {
     "unregistered": "Not registered",
-    "registered_only": "Registered only"
+    "registered_only": "Registered only",
+    "registered": "Registered"
   }
 }

--- a/pages/game-server-nodes/index.vue
+++ b/pages/game-server-nodes/index.vue
@@ -5,6 +5,7 @@ import FiveStackToolTip from "~/components/FiveStackToolTip.vue";
 import TacticalPageHeader from "~/components/TacticalPageHeader.vue";
 import FilterBar from "~/components/common/FilterBar.vue";
 import FilterMenu from "~/components/common/FilterMenu.vue";
+import FilterToggle from "~/components/common/FilterToggle.vue";
 import {
   PlusCircle,
   ArrowUpIcon,
@@ -234,40 +235,20 @@ const fadeTransition = {
         content-class="w-60 space-y-0.5 p-2"
         @reset="resetFilters"
       >
-        <button
-          type="button"
-          @click="toggleOnlyEnabled"
-          class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50"
-          :class="
-            onlyEnabled ? 'text-[hsl(var(--tac-amber))]' : 'text-foreground/90'
-          "
+        <FilterToggle
+          :model-value="onlyEnabled"
+          :label="$t('pages.game_server_nodes.only_enabled')"
+          @update:model-value="toggleOnlyEnabled"
         >
-          <span class="flex items-center gap-2">
-            <CircleDot class="h-3.5 w-3.5" />
-            {{ $t("pages.game_server_nodes.only_enabled") }}
-          </span>
-          <Check
-            v-if="onlyEnabled"
-            class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-          />
-        </button>
-        <button
-          type="button"
-          @click="toggleHideOffline"
-          class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50"
-          :class="
-            hideOffline ? 'text-[hsl(var(--tac-amber))]' : 'text-foreground/90'
-          "
+          <template #icon><CircleDot class="h-3.5 w-3.5" /></template>
+        </FilterToggle>
+        <FilterToggle
+          :model-value="hideOffline"
+          :label="$t('pages.game_server_nodes.hide_offline')"
+          @update:model-value="toggleHideOffline"
         >
-          <span class="flex items-center gap-2">
-            <Activity class="h-3.5 w-3.5" />
-            {{ $t("pages.game_server_nodes.hide_offline") }}
-          </span>
-          <Check
-            v-if="hideOffline"
-            class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-          />
-        </button>
+          <template #icon><Activity class="h-3.5 w-3.5" /></template>
+        </FilterToggle>
       </FilterMenu>
     </FilterBar>
   </PageTransition>

--- a/pages/leaderboard.vue
+++ b/pages/leaderboard.vue
@@ -63,6 +63,7 @@ interface LeaderboardEntry {
   player_steam_id: string;
   player_name: string;
   player_avatar_url: string | null;
+  player_custom_avatar_url: string | null;
   player_country: string | null;
   value: number;
   secondary_value: number | null;
@@ -217,6 +218,7 @@ const LEADERBOARD_QUERY = gql`
     $exclude_tournaments: Boolean!
     $role: String
     $season_id: uuid
+    $source: String
     $limit: Int
     $offset: Int
     $order_by: [leaderboard_entries_order_by!]
@@ -229,6 +231,7 @@ const LEADERBOARD_QUERY = gql`
         _exclude_tournaments: $exclude_tournaments
         _role: $role
         _season_id: $season_id
+        _source: $source
       }
       limit: $limit
       offset: $offset
@@ -237,6 +240,7 @@ const LEADERBOARD_QUERY = gql`
       player_steam_id
       player_name
       player_avatar_url
+      player_custom_avatar_url
       player_country
       value
       secondary_value
@@ -251,6 +255,7 @@ const LEADERBOARD_QUERY = gql`
         _exclude_tournaments: $exclude_tournaments
         _role: $role
         _season_id: $season_id
+        _source: $source
       }
     ) {
       aggregate {
@@ -267,6 +272,7 @@ const PLAYER_RANK_QUERY = gql`
     $match_type: String
     $exclude_tournaments: Boolean!
     $season_id: uuid
+    $source: String
     $player_steam_id: String!
   ) {
     get_player_leaderboard_rank(
@@ -276,6 +282,7 @@ const PLAYER_RANK_QUERY = gql`
         _match_type: $match_type
         _exclude_tournaments: $exclude_tournaments
         _season_id: $season_id
+        _source: $source
         _player_steam_id: $player_steam_id
       }
     ) {
@@ -298,6 +305,7 @@ const category = useRouteTab({
 
 const MATCH_TYPE_OPTIONS = ["all", "Competitive", "Wingman", "Duel"] as const;
 const ROLE_OPTIONS = ["all", "Sniper", "Entry", "Support", "Rifler"] as const;
+const SOURCE_OPTIONS = ["overall", "matchmaking", "tournament", "league"] as const;
 // Categories backed by per-map stats — the only ones the role view can scope.
 const ROLE_CATEGORIES = new Set([
   "best_rating",
@@ -360,6 +368,9 @@ const matchType = ref<string>(
 );
 const excludeTournaments = ref(false);
 const roleFilter = ref<string>(readQueryParam("role", ROLE_OPTIONS, "all"));
+const sourceFilter = ref<string>(
+  readQueryParam("source", SOURCE_OPTIONS, "overall"),
+);
 const supportsRole = computed(() => ROLE_CATEGORIES.has(category.value));
 
 // Default to the current season when seasons are on and one is active; otherwise
@@ -392,6 +403,7 @@ const leaderboardFilterCount = computed(() => {
   if (matchType.value !== "Competitive") n++;
   if (excludeTournaments.value) n++;
   if (supportsRole.value && roleFilter.value !== "all") n++;
+  if (sourceFilter.value !== "overall") n++;
   return n;
 });
 const scopeLabel = computed(() => {
@@ -492,6 +504,7 @@ const queryVariables = computed(() => ({
   exclude_tournaments: Boolean(excludeTournaments.value),
   role:
     supportsRole.value && roleFilter.value !== "all" ? roleFilter.value : null,
+  source: sourceFilter.value,
   limit: perPage.value,
   offset: offset.value,
   order_by: orderBy.value,
@@ -574,6 +587,7 @@ async function alignPageToHighlightedPlayer(): Promise<boolean> {
         season_id: derivedSeasonId.value,
         match_type: matchType.value === "all" ? null : matchType.value,
         exclude_tournaments: Boolean(excludeTournaments.value),
+        source: sourceFilter.value,
         player_steam_id: sid,
       },
       fetchPolicy: "network-only",
@@ -725,6 +739,7 @@ watch(scope, onFilterChange);
 watch(matchType, onFilterChange);
 watch(excludeTournaments, onFilterChange);
 watch(roleFilter, onFilterChange);
+watch(sourceFilter, onFilterChange);
 watch(highlightedSteamId, (sid) => {
   // A different player was deep-linked — re-resolve their page.
   if (sid && sid !== pageAlignedForSteamId) {
@@ -907,6 +922,19 @@ onMounted(async () => {
             <SelectItem value="Duel">{{
               $t("pages.leaderboard.match_types.duel")
             }}</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select v-model="sourceFilter">
+          <SelectTrigger class="h-8 w-[160px]">
+            <SelectValue
+              :placeholder="$t('pages.leaderboard.sources.overall')"
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem v-for="opt of SOURCE_OPTIONS" :key="opt" :value="opt">
+              {{ $t(`pages.leaderboard.sources.${opt}`) }}
+            </SelectItem>
           </SelectContent>
         </Select>
 
@@ -1343,6 +1371,7 @@ onMounted(async () => {
                         steam_id: entry.player_steam_id,
                         name: entry.player_name,
                         avatar_url: entry.player_avatar_url,
+                        custom_avatar_url: entry.player_custom_avatar_url,
                         country: entry.player_country,
                       }"
                       :show-elo="false"

--- a/pages/leaderboard.vue
+++ b/pages/leaderboard.vue
@@ -305,7 +305,12 @@ const category = useRouteTab({
 
 const MATCH_TYPE_OPTIONS = ["all", "Competitive", "Wingman", "Duel"] as const;
 const ROLE_OPTIONS = ["all", "Sniper", "Entry", "Support", "Rifler"] as const;
-const SOURCE_OPTIONS = ["overall", "matchmaking", "tournament", "league"] as const;
+const SOURCE_OPTIONS = [
+  "overall",
+  "matchmaking",
+  "tournament",
+  "league",
+] as const;
 // Categories backed by per-map stats — the only ones the role view can scope.
 const ROLE_CATEGORIES = new Set([
   "best_rating",
@@ -1061,6 +1066,28 @@ onMounted(async () => {
               </Select>
             </div>
 
+            <div class="space-y-2">
+              <span
+                class="font-mono text-[0.62rem] uppercase tracking-[0.2em] text-muted-foreground"
+              >
+                {{ $t("pages.leaderboard.sources.overall") }}
+              </span>
+              <Select v-model="sourceFilter">
+                <SelectTrigger class="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem
+                    v-for="opt of SOURCE_OPTIONS"
+                    :key="opt"
+                    :value="opt"
+                  >
+                    {{ $t(`pages.leaderboard.sources.${opt}`) }}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
             <div v-if="supportsRole" class="space-y-2">
               <span
                 class="font-mono text-[0.62rem] uppercase tracking-[0.2em] text-muted-foreground"
@@ -1125,6 +1152,15 @@ onMounted(async () => {
             @click="matchType = 'Competitive'"
           >
             {{ matchTypeLabel }}
+            <X class="h-3 w-3 opacity-70" />
+          </button>
+          <button
+            v-if="sourceFilter !== 'overall'"
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-full border border-[hsl(var(--tac-amber)/0.35)] bg-[hsl(var(--tac-amber)/0.12)] px-2.5 py-1 text-xs text-[hsl(var(--tac-amber))]"
+            @click="sourceFilter = 'overall'"
+          >
+            {{ $t(`pages.leaderboard.sources.${sourceFilter}`) }}
             <X class="h-3 w-3 opacity-70" />
           </button>
           <button

--- a/pages/matches/[id]/index.vue
+++ b/pages/matches/[id]/index.vue
@@ -414,19 +414,6 @@ const vsBaseClasses =
             <TimeAgo :date="match.cancels_at" countdown hide-icon />
           </span>
           <span
-            v-if="demoProcessingStartedAt"
-            class="inline-flex items-center gap-[0.3rem] text-[0.6rem] leading-none tracking-[0.12em]"
-            :title="$t('match.demo_processing')"
-          >
-            <span>{{ $t("match.demo_processing") }}</span>
-            <TimeAgo :date="demoProcessingStartedAt" seconds hide-icon />
-          </span>
-          <span
-            v-if="demoProcessingStartedAt && isNative && match.options?.best_of"
-            class="opacity-40"
-            >·</span
-          >
-          <span
             v-if="showAutoCancel && isNative && match.options?.best_of"
             class="opacity-40"
             >·</span
@@ -960,20 +947,6 @@ export default {
     },
     tournamentContext() {
       return this.match?.tournament_brackets?.[0]?.stage?.tournament ?? null;
-    },
-    // Anchored on the server's own timestamp, so a refresh keeps counting from
-    // when processing actually began rather than restarting at page load.
-    // Deliberately elapsed time, not a countdown: how long demo upload takes
-    // depends on tv_delay and transfer speed, so any predicted finish would be
-    // a guess that goes stale the moment it is wrong.
-    demoProcessingStartedAt() {
-      const processing = (this.match?.match_maps ?? []).find(
-        (matchMap: any) =>
-          matchMap.demo_processing_started_at &&
-          ["WaitingForTV", "UploadingDemo"].includes(matchMap.status),
-      );
-
-      return processing?.demo_processing_started_at ?? null;
     },
     showAutoCancel() {
       return (

--- a/pages/matches/[id]/index.vue
+++ b/pages/matches/[id]/index.vue
@@ -162,447 +162,472 @@ const vsBaseClasses =
 <template>
   <div class="flex flex-col gap-4 md:gap-6 w-full max-w-[1600px] mx-auto">
     <template v-if="match">
-    <PageTransition>
-      <header :class="heroClasses">
-        <div class="flex items-center gap-3 flex-wrap mb-5 max-sm:mb-[0.85rem]">
-          <span
-            :class="[
-              statusBaseClasses,
-              statusTierClasses[statusTier] || statusTierClasses.neutral,
-            ]"
+      <PageTransition>
+        <header :class="heroClasses">
+          <div
+            class="flex items-center gap-3 flex-wrap mb-5 max-sm:mb-[0.85rem]"
           >
-            <span class="w-[6px] h-[6px] bg-current rounded-full"></span>
-            {{ match.e_match_status?.description || match.status }}
-          </span>
-          <TimeAgo
-            v-if="
-              match.status === e_match_status_enum.Finished && match.ended_at
-            "
-            :date="match.ended_at"
-            class="font-mono text-[0.7rem] tracking-[0.2em] uppercase text-muted-foreground"
-          />
-          <span
-            v-if="match.label"
-            class="font-mono text-[0.7rem] tracking-[0.2em] uppercase text-muted-foreground"
-          >
-            {{ match.label }}
-          </span>
-          <NuxtLink
-            v-if="tournamentContext"
-            :to="`/tournaments/${tournamentContext.id}`"
-            class="inline-flex items-center gap-[0.4rem] font-mono text-[0.72rem] tracking-[0.15em] uppercase text-muted-foreground [transition:color_140ms_ease] hover:text-[hsl(var(--tac-amber))] max-sm:w-full max-sm:ml-0"
-          >
-            <span class="text-[hsl(var(--tac-amber))] text-[0.65rem]">◢</span>
-            {{ tournamentContext.name }}
-          </NuxtLink>
-
-          <div class="inline-flex items-center gap-2 ml-auto">
             <span
-              v-if="match.options?.type"
-              class="inline-flex items-center self-stretch px-[0.7rem] font-mono text-[0.62rem] font-bold uppercase tracking-[0.14em] leading-none rounded border border-border/70 bg-muted/35 text-muted-foreground"
+              :class="[
+                statusBaseClasses,
+                statusTierClasses[statusTier] || statusTierClasses.neutral,
+              ]"
             >
-              {{ match.options.type }}
+              <span class="w-[6px] h-[6px] bg-current rounded-full"></span>
+              {{ match.e_match_status?.description || match.status }}
             </span>
-            <MatchSourceBadge
-              v-if="match.source !== 'faceit'"
-              :source="match.source"
-              class="self-stretch px-[0.7rem] text-[0.62rem] leading-none"
+            <TimeAgo
+              v-if="
+                match.status === e_match_status_enum.Finished && match.ended_at
+              "
+              :date="match.ended_at"
+              class="font-mono text-[0.7rem] tracking-[0.2em] uppercase text-muted-foreground"
             />
-            <MatchActions :match="match" />
-          </div>
-        </div>
-
-        <div
-          class="flex flex-col gap-4 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:gap-6 items-stretch lg:items-center"
-        >
-          <div
-            class="flex items-center gap-3 min-w-0 justify-center text-center lg:justify-start lg:text-left"
-          >
-            <component
-              :is="lineup1TeamId ? 'NuxtLink' : 'div'"
-              :to="lineup1TeamId ? `/teams/${lineup1TeamId}` : undefined"
-              class="shrink-0 h-12 w-12 border border-[hsl(var(--tac-amber)/0.4)] bg-[hsl(var(--tac-amber)/0.1)] flex items-center justify-center overflow-hidden"
-              :class="
-                lineup1TeamId && 'transition-opacity hover:opacity-80 cursor-pointer'
-              "
-            >
-              <img
-                v-if="lineup1AvatarSrc"
-                :src="lineup1AvatarSrc"
-                :alt="lineup1Name"
-                class="h-full w-full object-cover"
-              />
-              <span
-                v-else
-                class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] text-[hsl(var(--tac-amber))]"
-              >
-                {{ (lineup1Name || "?").slice(0, 3) }}
-              </span>
-            </component>
-            <div
-              class="flex flex-col gap-[0.35rem] min-w-0 items-start lg:items-start"
-            >
-              <span
-                class="font-mono text-[0.6rem] tracking-[0.28em] uppercase text-muted-foreground/70"
-              >
-                {{ $t("match.lineup.lineup_1") }}
-              </span>
-              <NuxtLink
-                v-if="lineup1TeamId"
-                :to="`/teams/${lineup1TeamId}`"
-                :class="[
-                  teamClasses,
-                  match.winning_lineup_id === match.lineup_1_id && 'is-winner',
-                  'transition-opacity hover:opacity-80 cursor-pointer',
-                ]"
-              >
-                <span :class="teamGhostClasses" aria-hidden="true">
-                  {{ lineup1Name }}
-                </span>
-                <span
-                  :class="[
-                    teamMainClasses,
-                    match.winning_lineup_id === match.lineup_1_id &&
-                      teamMainWinnerClasses,
-                  ]"
-                >
-                  {{ lineup1Name }}
-                </span>
-              </NuxtLink>
-              <div
-                v-else
-                :class="[
-                  teamClasses,
-                  match.winning_lineup_id === match.lineup_1_id && 'is-winner',
-                ]"
-              >
-                <span :class="teamGhostClasses" aria-hidden="true">
-                  {{ lineup1Name }}
-                </span>
-                <span
-                  :class="[
-                    teamMainClasses,
-                    match.winning_lineup_id === match.lineup_1_id &&
-                      teamMainWinnerClasses,
-                  ]"
-                >
-                  {{ lineup1Name }}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <div class="flex items-center justify-center">
-            <div v-if="hasScores" class="inline-flex items-center gap-4">
-              <span
-                :class="[
-                  scoreClasses,
-                  mapScores.l1 > mapScores.l2 &&
-                    '!text-[hsl(var(--tac-amber))] [text-shadow:0_0_18px_hsl(var(--tac-amber)/0.35)]',
-                ]"
-              >
-                <AnimatedStat :value="mapScores.l1" />
-              </span>
-              <span :class="[vsBaseClasses, 'uppercase']">{{
-                $t("common.vs")
-              }}</span>
-              <span
-                :class="[
-                  scoreClasses,
-                  mapScores.l2 > mapScores.l1 &&
-                    '!text-[hsl(var(--tac-amber))] [text-shadow:0_0_18px_hsl(var(--tac-amber)/0.35)]',
-                ]"
-              >
-                <AnimatedStat :value="mapScores.l2" />
-              </span>
-            </div>
             <span
-              v-else
-              :class="[vsBaseClasses, 'text-base px-4 py-[0.6rem] uppercase']"
-              >{{ $t("common.vs") }}</span
+              v-if="match.label"
+              class="font-mono text-[0.7rem] tracking-[0.2em] uppercase text-muted-foreground"
             >
+              {{ match.label }}
+            </span>
+            <NuxtLink
+              v-if="tournamentContext"
+              :to="`/tournaments/${tournamentContext.id}`"
+              class="inline-flex items-center gap-[0.4rem] font-mono text-[0.72rem] tracking-[0.15em] uppercase text-muted-foreground [transition:color_140ms_ease] hover:text-[hsl(var(--tac-amber))] max-sm:w-full max-sm:ml-0"
+            >
+              <span class="text-[hsl(var(--tac-amber))] text-[0.65rem]">◢</span>
+              {{ tournamentContext.name }}
+            </NuxtLink>
+
+            <div class="inline-flex items-center gap-2 ml-auto">
+              <span
+                v-if="match.options?.type"
+                class="inline-flex items-center self-stretch px-[0.7rem] font-mono text-[0.62rem] font-bold uppercase tracking-[0.14em] leading-none rounded border border-border/70 bg-muted/35 text-muted-foreground"
+              >
+                {{ match.options.type }}
+              </span>
+              <MatchSourceBadge
+                v-if="match.source !== 'faceit'"
+                :source="match.source"
+                class="self-stretch px-[0.7rem] text-[0.62rem] leading-none"
+              />
+              <MatchActions :match="match" />
+            </div>
           </div>
 
           <div
-            class="flex items-center gap-3 min-w-0 justify-center text-center lg:justify-end lg:text-right flex-row-reverse lg:flex-row"
+            class="flex flex-col gap-4 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:gap-6 items-stretch lg:items-center"
           >
             <div
-              class="flex flex-col gap-[0.35rem] min-w-0 items-start lg:items-end"
+              class="flex items-center gap-3 min-w-0 justify-center text-center lg:justify-start lg:text-left"
             >
-              <span
-                class="font-mono text-[0.6rem] tracking-[0.28em] uppercase text-muted-foreground/70"
+              <component
+                :is="lineup1TeamId ? 'NuxtLink' : 'div'"
+                :to="lineup1TeamId ? `/teams/${lineup1TeamId}` : undefined"
+                class="shrink-0 h-12 w-12 border border-[hsl(var(--tac-amber)/0.4)] bg-[hsl(var(--tac-amber)/0.1)] flex items-center justify-center overflow-hidden"
+                :class="
+                  lineup1TeamId &&
+                  'transition-opacity hover:opacity-80 cursor-pointer'
+                "
               >
-                {{ $t("match.lineup.lineup_2") }}
-              </span>
-              <NuxtLink
-                v-if="lineup2TeamId"
-                :to="`/teams/${lineup2TeamId}`"
-                :class="[
-                  teamClasses,
-                  match.winning_lineup_id === match.lineup_2_id && 'is-winner',
-                  'transition-opacity hover:opacity-80 cursor-pointer',
-                ]"
-              >
-                <span :class="teamGhostClasses" aria-hidden="true">
-                  {{ lineup2Name }}
-                </span>
+                <img
+                  v-if="lineup1AvatarSrc"
+                  :src="lineup1AvatarSrc"
+                  :alt="lineup1Name"
+                  class="h-full w-full object-cover"
+                />
                 <span
-                  :class="[
-                    teamMainClasses,
-                    match.winning_lineup_id === match.lineup_2_id &&
-                      teamMainWinnerClasses,
-                  ]"
+                  v-else
+                  class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] text-[hsl(var(--tac-amber))]"
                 >
-                  {{ lineup2Name }}
+                  {{ (lineup1Name || "?").slice(0, 3) }}
                 </span>
-              </NuxtLink>
+              </component>
               <div
-                v-else
-                :class="[
-                  teamClasses,
-                  match.winning_lineup_id === match.lineup_2_id && 'is-winner',
-                ]"
+                class="flex flex-col gap-[0.35rem] min-w-0 items-start lg:items-start"
               >
-                <span :class="teamGhostClasses" aria-hidden="true">
-                  {{ lineup2Name }}
-                </span>
                 <span
+                  class="font-mono text-[0.6rem] tracking-[0.28em] uppercase text-muted-foreground/70"
+                >
+                  {{ $t("match.lineup.lineup_1") }}
+                </span>
+                <NuxtLink
+                  v-if="lineup1TeamId"
+                  :to="`/teams/${lineup1TeamId}`"
                   :class="[
-                    teamMainClasses,
-                    match.winning_lineup_id === match.lineup_2_id &&
-                      teamMainWinnerClasses,
+                    teamClasses,
+                    match.winning_lineup_id === match.lineup_1_id &&
+                      'is-winner',
+                    'transition-opacity hover:opacity-80 cursor-pointer',
                   ]"
                 >
-                  {{ lineup2Name }}
-                </span>
+                  <span :class="teamGhostClasses" aria-hidden="true">
+                    {{ lineup1Name }}
+                  </span>
+                  <span
+                    :class="[
+                      teamMainClasses,
+                      match.winning_lineup_id === match.lineup_1_id &&
+                        teamMainWinnerClasses,
+                    ]"
+                  >
+                    {{ lineup1Name }}
+                  </span>
+                </NuxtLink>
+                <div
+                  v-else
+                  :class="[
+                    teamClasses,
+                    match.winning_lineup_id === match.lineup_1_id &&
+                      'is-winner',
+                  ]"
+                >
+                  <span :class="teamGhostClasses" aria-hidden="true">
+                    {{ lineup1Name }}
+                  </span>
+                  <span
+                    :class="[
+                      teamMainClasses,
+                      match.winning_lineup_id === match.lineup_1_id &&
+                        teamMainWinnerClasses,
+                    ]"
+                  >
+                    {{ lineup1Name }}
+                  </span>
+                </div>
               </div>
             </div>
-            <component
-              :is="lineup2TeamId ? 'NuxtLink' : 'div'"
-              :to="lineup2TeamId ? `/teams/${lineup2TeamId}` : undefined"
-              class="shrink-0 h-12 w-12 border border-[hsl(var(--tac-amber)/0.4)] bg-[hsl(var(--tac-amber)/0.1)] flex items-center justify-center overflow-hidden"
-              :class="
-                lineup2TeamId && 'transition-opacity hover:opacity-80 cursor-pointer'
-              "
-            >
-              <img
-                v-if="lineup2AvatarSrc"
-                :src="lineup2AvatarSrc"
-                :alt="lineup2Name"
-                class="h-full w-full object-cover"
-              />
+
+            <div class="flex items-center justify-center">
+              <div v-if="hasScores" class="inline-flex items-center gap-4">
+                <span
+                  :class="[
+                    scoreClasses,
+                    mapScores.l1 > mapScores.l2 &&
+                      '!text-[hsl(var(--tac-amber))] [text-shadow:0_0_18px_hsl(var(--tac-amber)/0.35)]',
+                  ]"
+                >
+                  <AnimatedStat :value="mapScores.l1" />
+                </span>
+                <span :class="[vsBaseClasses, 'uppercase']">{{
+                  $t("common.vs")
+                }}</span>
+                <span
+                  :class="[
+                    scoreClasses,
+                    mapScores.l2 > mapScores.l1 &&
+                      '!text-[hsl(var(--tac-amber))] [text-shadow:0_0_18px_hsl(var(--tac-amber)/0.35)]',
+                  ]"
+                >
+                  <AnimatedStat :value="mapScores.l2" />
+                </span>
+              </div>
               <span
                 v-else
-                class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] text-[hsl(var(--tac-amber))]"
+                :class="[vsBaseClasses, 'text-base px-4 py-[0.6rem] uppercase']"
+                >{{ $t("common.vs") }}</span
               >
-                {{ (lineup2Name || "?").slice(0, 3) }}
-              </span>
-            </component>
-          </div>
-        </div>
+            </div>
 
-        <div
-          class="flex items-center gap-[0.6rem] justify-center flex-wrap mt-4 pt-[0.85rem] border-t border-border font-mono text-[0.72rem] tracking-[0.15em] uppercase text-muted-foreground"
-        >
-          <span
-            v-if="showAutoCancel"
-            class="inline-flex items-center gap-[0.3rem] text-[0.6rem] leading-none tracking-[0.12em] text-destructive"
-            :title="$t('match.auto_canceling')"
-          >
-            <AlertTriangle class="w-2.5 h-2.5 shrink-0" />
-            <span>{{ $t("match.auto_canceling") }}</span>
-            <TimeAgo :date="match.cancels_at" countdown hide-icon />
-          </span>
-          <span
-            v-if="showAutoCancel && isNative && match.options?.best_of"
-            class="opacity-40"
-            >·</span
-          >
-          <span v-if="isNative && match.options?.best_of">
-            {{
-              $t("match.options.best_of.option", {
-                count: match.options.best_of,
-              })
-            }}
-          </span>
-          <span
-            v-if="isNative && match.e_region?.description"
-            class="opacity-40"
-            >·</span
-          >
-          <span v-if="isNative && match.e_region?.description">
-            {{ match.e_region.description }}
-          </span>
-          <span v-if="isNative && formattedSchedule" class="opacity-40">·</span>
-          <span v-if="formattedSchedule">
-            {{ formattedSchedule }}
-          </span>
-        </div>
-      </header>
-    </PageTransition>
-
-    <PageTransition v-if="hasMatchClips" :delay="60">
-      <MatchHighlightsReel :match="match" />
-    </PageTransition>
-
-    <div
-      class="grid items-start gap-4 md:gap-6 lg:gap-8 grid-cols-1 lg:grid-cols-[minmax(320px,_400px)_minmax(0,1fr)]"
-    >
-      <!-- Left column: match info, chat, maps. On desktop it's the
-           first grid column; on mobile it drops below the stream. -->
-      <div
-        class="grid grid-cols-1 gap-y-4 md:gap-y-6 min-w-0"
-        :class="showLiveStreamBlock ? 'order-2 lg:order-none' : ''"
-      >
-        <PageTransition :delay="100">
-          <MatchInfo :match="match"></MatchInfo>
-        </PageTransition>
-
-        <PageTransition :delay="200">
-          <ChatLobby
-            class="max-h-96"
-            instance="matches/id"
-            type="match"
-            :lobby-id="match.id"
-            :play-notification-sound="match.status !== e_match_status_enum.Live"
-            v-if="canJoinLobby"
-          />
-        </PageTransition>
-
-        <PageTransition :delay="200">
-          <ChatLobby
-            class="max-h-96"
-            instance="matches/id"
-            type="match_team"
-            :lobby-id="`${match.id}:${myLineupId}`"
-            :play-notification-sound="match.status !== e_match_status_enum.Live"
-            v-if="myLineupId"
-          />
-        </PageTransition>
-
-        <PageTransition :delay="200">
-          <div
-            v-if="match.options.best_of && match.options.best_of > 0"
-            class="flex flex-col gap-3"
-          >
-            <div v-for="(slot, index) in mapSlots" :key="index">
-              <MatchMaps
-                v-if="slot"
-                :match="match"
-                :match-map="slot"
-                :is-active="activeStatsMap?.id === slot.id"
-                @open-stats="activeStatsMap = $event"
-              ></MatchMaps>
+            <div
+              class="flex items-center gap-3 min-w-0 justify-center text-center lg:justify-end lg:text-right flex-row-reverse lg:flex-row"
+            >
               <div
-                v-else
-                class="rounded-xl overflow-hidden border-2 border-dashed border-border/60"
+                class="flex flex-col gap-[0.35rem] min-w-0 items-start lg:items-end"
+              >
+                <span
+                  class="font-mono text-[0.6rem] tracking-[0.28em] uppercase text-muted-foreground/70"
+                >
+                  {{ $t("match.lineup.lineup_2") }}
+                </span>
+                <NuxtLink
+                  v-if="lineup2TeamId"
+                  :to="`/teams/${lineup2TeamId}`"
+                  :class="[
+                    teamClasses,
+                    match.winning_lineup_id === match.lineup_2_id &&
+                      'is-winner',
+                    'transition-opacity hover:opacity-80 cursor-pointer',
+                  ]"
+                >
+                  <span :class="teamGhostClasses" aria-hidden="true">
+                    {{ lineup2Name }}
+                  </span>
+                  <span
+                    :class="[
+                      teamMainClasses,
+                      match.winning_lineup_id === match.lineup_2_id &&
+                        teamMainWinnerClasses,
+                    ]"
+                  >
+                    {{ lineup2Name }}
+                  </span>
+                </NuxtLink>
+                <div
+                  v-else
+                  :class="[
+                    teamClasses,
+                    match.winning_lineup_id === match.lineup_2_id &&
+                      'is-winner',
+                  ]"
+                >
+                  <span :class="teamGhostClasses" aria-hidden="true">
+                    {{ lineup2Name }}
+                  </span>
+                  <span
+                    :class="[
+                      teamMainClasses,
+                      match.winning_lineup_id === match.lineup_2_id &&
+                        teamMainWinnerClasses,
+                    ]"
+                  >
+                    {{ lineup2Name }}
+                  </span>
+                </div>
+              </div>
+              <component
+                :is="lineup2TeamId ? 'NuxtLink' : 'div'"
+                :to="lineup2TeamId ? `/teams/${lineup2TeamId}` : undefined"
+                class="shrink-0 h-12 w-12 border border-[hsl(var(--tac-amber)/0.4)] bg-[hsl(var(--tac-amber)/0.1)] flex items-center justify-center overflow-hidden"
+                :class="
+                  lineup2TeamId &&
+                  'transition-opacity hover:opacity-80 cursor-pointer'
+                "
+              >
+                <img
+                  v-if="lineup2AvatarSrc"
+                  :src="lineup2AvatarSrc"
+                  :alt="lineup2Name"
+                  class="h-full w-full object-cover"
+                />
+                <span
+                  v-else
+                  class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] text-[hsl(var(--tac-amber))]"
+                >
+                  {{ (lineup2Name || "?").slice(0, 3) }}
+                </span>
+              </component>
+            </div>
+          </div>
+
+          <div
+            class="flex items-center gap-[0.6rem] justify-center flex-wrap mt-4 pt-[0.85rem] border-t border-border font-mono text-[0.72rem] tracking-[0.15em] uppercase text-muted-foreground"
+          >
+            <span
+              v-if="showAutoCancel"
+              class="inline-flex items-center gap-[0.3rem] text-[0.6rem] leading-none tracking-[0.12em] text-destructive"
+              :title="$t('match.auto_canceling')"
+            >
+              <AlertTriangle class="w-2.5 h-2.5 shrink-0" />
+              <span>{{ $t("match.auto_canceling") }}</span>
+              <TimeAgo :date="match.cancels_at" countdown hide-icon />
+            </span>
+            <span
+              v-if="showAutoCancel && isNative && match.options?.best_of"
+              class="opacity-40"
+              >·</span
+            >
+            <span v-if="isNative && match.options?.best_of">
+              {{
+                $t("match.options.best_of.option", {
+                  count: match.options.best_of,
+                })
+              }}
+            </span>
+            <span
+              v-if="isNative && match.e_region?.description"
+              class="opacity-40"
+              >·</span
+            >
+            <span v-if="isNative && match.e_region?.description">
+              {{ match.e_region.description }}
+            </span>
+            <span v-if="isNative && formattedSchedule" class="opacity-40"
+              >·</span
+            >
+            <span v-if="formattedSchedule">
+              {{ formattedSchedule }}
+            </span>
+          </div>
+        </header>
+      </PageTransition>
+
+      <PageTransition v-if="hasMatchClips" :delay="60">
+        <MatchHighlightsReel :match="match" />
+      </PageTransition>
+
+      <div
+        class="grid items-start gap-4 md:gap-6 lg:gap-8 grid-cols-1 lg:grid-cols-[minmax(320px,_400px)_minmax(0,1fr)]"
+      >
+        <!-- Left column: match info, chat, maps. On desktop it's the
+           first grid column; on mobile it drops below the stream. -->
+        <div
+          class="grid grid-cols-1 gap-y-4 md:gap-y-6 min-w-0"
+          :class="showLiveStreamBlock ? 'order-2 lg:order-none' : ''"
+        >
+          <PageTransition :delay="100">
+            <MatchInfo :match="match"></MatchInfo>
+          </PageTransition>
+
+          <PageTransition :delay="200">
+            <ChatLobby
+              class="max-h-96"
+              instance="matches/id"
+              type="match"
+              :label="$t('chat.everyone')"
+              :lobby-id="match.id"
+              :play-notification-sound="
+                match.status !== e_match_status_enum.Live
+              "
+              v-if="canJoinLobby"
+            />
+          </PageTransition>
+
+          <PageTransition :delay="200">
+            <!-- Same status gate as the match room above: chat closes with the
+               match, and being on a lineup is not a reason to keep a room open
+               on something that finished. -->
+            <ChatLobby
+              class="max-h-96"
+              instance="matches/id"
+              type="match_team"
+              :label="$t('chat.your_team')"
+              :lobby-id="`${match.id}:${myLineupId}`"
+              :play-notification-sound="
+                match.status !== e_match_status_enum.Live
+              "
+              v-if="myLineupId && canJoinLobby"
+            />
+          </PageTransition>
+
+          <PageTransition :delay="200">
+            <div
+              v-if="match.options.best_of && match.options.best_of > 0"
+              class="flex flex-col gap-3"
+            >
+              <div v-for="(slot, index) in mapSlots" :key="index">
+                <MatchMaps
+                  v-if="slot"
+                  :match="match"
+                  :match-map="slot"
+                  :is-active="activeStatsMap?.id === slot.id"
+                  @open-stats="activeStatsMap = $event"
+                ></MatchMaps>
+                <div
+                  v-else
+                  class="rounded-xl overflow-hidden border-2 border-dashed border-border/60"
+                >
+                  <div
+                    class="aspect-[16/5] bg-muted/40 flex items-center justify-center text-muted-foreground"
+                  >
+                    <div class="flex flex-col items-center gap-1">
+                      <span
+                        class="text-sm uppercase tracking-wide font-semibold"
+                      >
+                        {{ $t("match.map_number", { count: index + 1 }) }}
+                      </span>
+                      <span class="text-xs">
+                        {{ $t("match.map_tbd") }}
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="bg-muted/40 border-t border-border/30 px-3 py-2.5"
+                  >
+                    <div class="flex items-center justify-center">
+                      <span class="text-xs text-muted-foreground">—</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                v-show="showVetoPicks && vetoPickCount !== 0"
+                class="rounded-xl border border-border/40 bg-card/40 px-1.5 py-1.5"
               >
                 <div
-                  class="aspect-[16/5] bg-muted/40 flex items-center justify-center text-muted-foreground"
+                  class="font-mono text-[0.6rem] font-bold tracking-[0.28em] uppercase text-muted-foreground/70 text-center mb-1"
                 >
-                  <div class="flex flex-col items-center gap-1">
-                    <span class="text-sm uppercase tracking-wide font-semibold">
-                      {{ $t("match.map_number", { count: index + 1 }) }}
-                    </span>
-                    <span class="text-xs">
-                      {{ $t("match.map_tbd") }}
-                    </span>
-                  </div>
+                  {{ $t("common.map_veto") }}
                 </div>
-                <div class="bg-muted/40 border-t border-border/30 px-3 py-2.5">
-                  <div class="flex items-center justify-center">
-                    <span class="text-xs text-muted-foreground">—</span>
-                  </div>
-                </div>
+                <MatchPicksDisplay
+                  v-if="showVetoPicks"
+                  :match="match"
+                  @update:count="vetoPickCount = $event"
+                />
               </div>
             </div>
-            <div
-              v-show="showVetoPicks && vetoPickCount !== 0"
-              class="rounded-xl border border-border/40 bg-card/40 px-1.5 py-1.5"
-            >
-              <div
-                class="font-mono text-[0.6rem] font-bold tracking-[0.28em] uppercase text-muted-foreground/70 text-center mb-1"
-              >
-                {{ $t("common.map_veto") }}
-              </div>
-              <MatchPicksDisplay
-                v-if="showVetoPicks"
-                :match="match"
-                @update:count="vetoPickCount = $event"
-              />
-            </div>
-          </div>
-        </PageTransition>
-      </div>
+          </PageTransition>
+        </div>
 
-      <!-- Right column: the live stream surface (game-streamer rows
+        <!-- Right column: the live stream surface (game-streamer rows
            get the full WHEP LiveStreamPlayer; embeds stay in
            StreamEmbed) stacked above the scoreboard/tabs. On mobile it
            rises above the left column so the stream leads. -->
-      <div
-        class="min-w-0 flex flex-col gap-4 md:gap-6"
-        :class="showLiveStreamBlock ? 'order-1 lg:order-none' : ''"
-      >
-        <PageTransition v-if="showLiveStreamBlock">
-          <div class="min-w-0 space-y-4">
-            <LiveStreamPlayer
-              v-if="hasGameStreamer"
-              :match-id="match.id"
-              class="max-w-[1500px] w-full"
-            />
-            <StreamEmbed
-              v-if="embeddableStreams.length > 0"
-              :streams="embeddableStreams"
-              :match-id="match.id"
-              class="max-w-[1500px] w-full overflow-x-auto"
-            />
+        <div
+          class="min-w-0 flex flex-col gap-4 md:gap-6"
+          :class="showLiveStreamBlock ? 'order-1 lg:order-none' : ''"
+        >
+          <PageTransition v-if="showLiveStreamBlock">
+            <div class="min-w-0 space-y-4">
+              <LiveStreamPlayer
+                v-if="hasGameStreamer"
+                :match-id="match.id"
+                class="max-w-[1500px] w-full"
+              />
+              <StreamEmbed
+                v-if="embeddableStreams.length > 0"
+                :streams="embeddableStreams"
+                :match-id="match.id"
+                class="max-w-[1500px] w-full overflow-x-auto"
+              />
+            </div>
+          </PageTransition>
+
+          <div class="min-w-0">
+            <PageTransition :delay="100">
+              <template
+                v-if="
+                  regions.length === 0 &&
+                  match.options.region_veto &&
+                  !match.region
+                "
+              >
+                <Alert
+                  variant="destructive"
+                  class="bg-red-600 text-white max-w-md mb-6"
+                >
+                  <AlertTitle>{{
+                    $t("match.region_veto.no_regions_available")
+                  }}</AlertTitle>
+                  <AlertDescription>
+                    {{
+                      $t("match.region_veto.no_regions_available_description")
+                    }}
+                  </AlertDescription>
+                </Alert>
+              </template>
+            </PageTransition>
+
+            <PageTransition :delay="100">
+              <MatchRegionVeto :match="match" class="pb-6" />
+            </PageTransition>
+
+            <PageTransition :delay="100">
+              <MatchMapVeto :match="match" class="pb-6" />
+            </PageTransition>
+
+            <PageTransition :delay="200">
+              <MatchTabs
+                :match="match"
+                :active-map="activeStatsMap"
+                @clear-active-map="activeStatsMap = null"
+                @select-map="activeStatsMap = $event"
+              ></MatchTabs>
+            </PageTransition>
           </div>
-        </PageTransition>
-
-        <div class="min-w-0">
-          <PageTransition :delay="100">
-            <template
-              v-if="
-                regions.length === 0 &&
-                match.options.region_veto &&
-                !match.region
-              "
-            >
-            <Alert
-              variant="destructive"
-              class="bg-red-600 text-white max-w-md mb-6"
-            >
-              <AlertTitle>{{
-                $t("match.region_veto.no_regions_available")
-              }}</AlertTitle>
-              <AlertDescription>
-                {{ $t("match.region_veto.no_regions_available_description") }}
-              </AlertDescription>
-            </Alert>
-          </template>
-        </PageTransition>
-
-        <PageTransition :delay="100">
-          <MatchRegionVeto :match="match" class="pb-6" />
-        </PageTransition>
-
-        <PageTransition :delay="100">
-          <MatchMapVeto :match="match" class="pb-6" />
-        </PageTransition>
-
-        <PageTransition :delay="200">
-          <MatchTabs
-            :match="match"
-            :active-map="activeStatsMap"
-            @clear-active-map="activeStatsMap = null"
-            @select-map="activeStatsMap = $event"
-          ></MatchTabs>
-        </PageTransition>
         </div>
       </div>
-    </div>
 
-    <MatchAdminBottomBar v-if="match.is_organizer" :match="match" />
+      <MatchAdminBottomBar v-if="match.is_organizer" :match="match" />
     </template>
   </div>
 </template>

--- a/pages/matches/[id]/index.vue
+++ b/pages/matches/[id]/index.vue
@@ -411,8 +411,21 @@ const vsBaseClasses =
           >
             <AlertTriangle class="w-2.5 h-2.5 shrink-0" />
             <span>{{ $t("match.auto_canceling") }}</span>
-            <TimeAgo :date="match.cancels_at" hide-icon />
+            <TimeAgo :date="match.cancels_at" countdown hide-icon />
           </span>
+          <span
+            v-if="demoProcessingStartedAt"
+            class="inline-flex items-center gap-[0.3rem] text-[0.6rem] leading-none tracking-[0.12em]"
+            :title="$t('match.demo_processing')"
+          >
+            <span>{{ $t("match.demo_processing") }}</span>
+            <TimeAgo :date="demoProcessingStartedAt" seconds hide-icon />
+          </span>
+          <span
+            v-if="demoProcessingStartedAt && isNative && match.options?.best_of"
+            class="opacity-40"
+            >·</span
+          >
           <span
             v-if="showAutoCancel && isNative && match.options?.best_of"
             class="opacity-40"
@@ -466,6 +479,17 @@ const vsBaseClasses =
             :lobby-id="match.id"
             :play-notification-sound="match.status !== e_match_status_enum.Live"
             v-if="canJoinLobby"
+          />
+        </PageTransition>
+
+        <PageTransition :delay="200">
+          <ChatLobby
+            class="max-h-96"
+            instance="matches/id"
+            type="match_team"
+            :lobby-id="`${match.id}:${myLineupId}`"
+            :play-notification-sound="match.status !== e_match_status_enum.Live"
+            v-if="myLineupId"
           />
         </PageTransition>
 
@@ -712,6 +736,7 @@ export default {
                   lineup_2_side: true,
                   map: mapFields,
                   is_current_map: true,
+                  demo_processing_started_at: true,
                   demos_total_size: true,
                   demos_download_url: true,
                   status: true,
@@ -936,6 +961,20 @@ export default {
     tournamentContext() {
       return this.match?.tournament_brackets?.[0]?.stage?.tournament ?? null;
     },
+    // Anchored on the server's own timestamp, so a refresh keeps counting from
+    // when processing actually began rather than restarting at page load.
+    // Deliberately elapsed time, not a countdown: how long demo upload takes
+    // depends on tv_delay and transfer speed, so any predicted finish would be
+    // a guess that goes stale the moment it is wrong.
+    demoProcessingStartedAt() {
+      const processing = (this.match?.match_maps ?? []).find(
+        (matchMap: any) =>
+          matchMap.demo_processing_started_at &&
+          ["WaitingForTV", "UploadingDemo"].includes(matchMap.status),
+      );
+
+      return processing?.demo_processing_started_at ?? null;
+    },
     showAutoCancel() {
       return (
         this.match?.cancels_at &&
@@ -1001,6 +1040,24 @@ export default {
       return useApplicationSettingsStore().availableRegions.filter((region) => {
         return region.is_lan === false;
       });
+    },
+    // The lineup this viewer plays for, or coaches. Organizers and spectators
+    // get nothing -- team chat is private to the side actually playing. The API
+    // re-checks this on join; this only decides what to render.
+    myLineupId() {
+      if (!this.match) {
+        return null;
+      }
+
+      const mySteamId = useAuthStore().me?.steam_id;
+
+      const mine = [this.match.lineup_1, this.match.lineup_2].find(
+        (lineup) =>
+          lineup?.is_on_lineup ||
+          (mySteamId && lineup?.coach?.steam_id === mySteamId),
+      );
+
+      return mine?.id ?? null;
     },
     canJoinLobby() {
       if (!this.match) {

--- a/pages/matches/index.vue
+++ b/pages/matches/index.vue
@@ -24,6 +24,7 @@ import PlayerSearch from "~/components/PlayerSearch.vue";
 import TeamSearch from "~/components/teams/TeamSearch.vue";
 import FilterBar from "~/components/common/FilterBar.vue";
 import FilterMenu from "~/components/common/FilterMenu.vue";
+import FilterToggle from "~/components/common/FilterToggle.vue";
 import { Avatar, AvatarImage, AvatarFallback } from "~/components/ui/avatar";
 
 const apiDomain = useRuntimeConfig().public.apiDomain;
@@ -116,200 +117,200 @@ function optionRowClass(active: boolean) {
 
   <PageTransition :delay="100" class="mt-6">
     <FilterBar>
-          <!-- Status -->
-          <Popover>
-            <PopoverTrigger as-child>
-              <button
-                type="button"
-                :class="[
-                  filterTriggerBase,
-                  form.statuses.length
-                    ? filterTriggerActive
-                    : filterTriggerIdle,
-                ]"
-              >
-                <Activity class="h-3.5 w-3.5" />
-                {{ $t("pages.matches.status_label") }}
-                <span v-if="form.statuses.length" :class="filterBadgeClasses">
-                  {{ form.statuses.length }}
-                </span>
-                <ChevronDown class="h-3 w-3 opacity-50" />
-              </button>
-            </PopoverTrigger>
-            <PopoverContent align="start" class="w-60 p-2">
-              <div class="mb-2 flex flex-wrap gap-1.5">
-                <button
-                  type="button"
-                  @click="applyStatusPreset('upcomingLive')"
-                  :class="[
-                    presetBase,
-                    activePresetName === 'upcomingLive'
-                      ? presetActive
-                      : presetIdle,
-                  ]"
-                >
-                  {{ $t("pages.matches.preset_upcoming_live") }}
-                </button>
-                <button
-                  type="button"
-                  @click="applyStatusPreset('finished')"
-                  :class="[
-                    presetBase,
-                    activePresetName === 'finished' ? presetActive : presetIdle,
-                  ]"
-                >
-                  {{ $t("pages.matches.preset_finished") }}
-                </button>
-              </div>
-              <div class="max-h-60 space-y-0.5 overflow-y-auto">
-                <button
-                  v-for="status in matchStatusOptions"
-                  :key="status.value"
-                  type="button"
-                  @click="toggleStatus(status.value)"
-                  class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs text-foreground/90 transition-colors hover:bg-muted/50"
-                >
-                  <span>{{ status.label }}</span>
-                  <Check
-                    v-if="form.statuses.includes(status.value)"
-                    class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-                  />
-                </button>
-              </div>
-              <button
-                v-if="form.statuses.length"
-                type="button"
-                @click="clearAllStatuses"
-                class="mt-2 flex w-full items-center justify-center gap-1 rounded border border-border px-2 py-1 font-mono text-[0.6rem] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <X class="h-3 w-3" /> {{ $t("pages.matches.clear_short") }}
-              </button>
-            </PopoverContent>
-          </Popover>
-
-          <!-- Filters (teams, players, date window, options) — pinned right -->
-          <FilterMenu
-            class="ml-auto"
-            :count="filtersDrawerCount"
-            :active="filtersDrawerCount > 0"
-            :show-reset="!!activeFilterCount"
-            content-class="w-[min(92vw,340px)] space-y-3 p-3"
-            @reset="resetFilters"
+      <!-- Status -->
+      <Popover>
+        <PopoverTrigger as-child>
+          <button
+            type="button"
+            :class="[
+              filterTriggerBase,
+              form.statuses.length ? filterTriggerActive : filterTriggerIdle,
+            ]"
           >
-          <!-- Teams -->
-          <div class="space-y-1.5">
-            <span
-              class="block px-1 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
-            >
-              {{ $t("pages.matches.teams") }}
+            <Activity class="h-3.5 w-3.5" />
+            {{ $t("pages.matches.status_label") }}
+            <span v-if="form.statuses.length" :class="filterBadgeClasses">
+              {{ form.statuses.length }}
             </span>
-            <TeamSearch
-              :label="$t('pages.manage_matches.enter_team_name')"
-              :exclude="form.teams.map((t) => t.id)"
-              @selected="addTeam"
+            <ChevronDown class="h-3 w-3 opacity-50" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" class="w-60 p-2">
+          <div class="mb-2 flex flex-wrap gap-1.5">
+            <button
+              type="button"
+              @click="applyStatusPreset('upcomingLive')"
+              :class="[
+                presetBase,
+                activePresetName === 'upcomingLive' ? presetActive : presetIdle,
+              ]"
             >
+              {{ $t("pages.matches.preset_upcoming_live") }}
+            </button>
+            <button
+              type="button"
+              @click="applyStatusPreset('finished')"
+              :class="[
+                presetBase,
+                activePresetName === 'finished' ? presetActive : presetIdle,
+              ]"
+            >
+              {{ $t("pages.matches.preset_finished") }}
+            </button>
+          </div>
+          <div class="max-h-60 space-y-0.5 overflow-y-auto">
+            <button
+              v-for="status in matchStatusOptions"
+              :key="status.value"
+              type="button"
+              @click="toggleStatus(status.value)"
+              class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs text-foreground/90 transition-colors hover:bg-muted/50"
+            >
+              <span>{{ status.label }}</span>
+              <Check
+                v-if="form.statuses.includes(status.value)"
+                class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
+              />
+            </button>
+          </div>
+          <button
+            v-if="form.statuses.length"
+            type="button"
+            @click="clearAllStatuses"
+            class="mt-2 flex w-full items-center justify-center gap-1 rounded border border-border px-2 py-1 font-mono text-[0.6rem] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <X class="h-3 w-3" /> {{ $t("pages.matches.clear_short") }}
+          </button>
+        </PopoverContent>
+      </Popover>
+
+      <!-- Filters (teams, players, date window, options) — pinned right -->
+      <FilterMenu
+        class="ml-auto"
+        :count="filtersDrawerCount"
+        :active="filtersDrawerCount > 0"
+        :show-reset="!!activeFilterCount"
+        content-class="w-[min(92vw,340px)] space-y-3 p-3"
+        @reset="resetFilters"
+      >
+        <!-- Teams -->
+        <div class="space-y-1.5">
+          <span
+            class="block px-1 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
+          >
+            {{ $t("pages.matches.teams") }}
+          </span>
+          <TeamSearch
+            :label="$t('pages.manage_matches.enter_team_name')"
+            :exclude="form.teams.map((t) => t.id)"
+            @selected="addTeam"
+          >
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+            >
+              <Users class="h-3.5 w-3.5 shrink-0" />
+              <span
+                class="flex-1 truncate text-left normal-case tracking-normal"
+              >
+                {{ $t("pages.manage_matches.enter_team_name") }}
+              </span>
+              <ChevronDown class="h-3 w-3 shrink-0 opacity-50" />
+            </button>
+          </TeamSearch>
+          <div v-if="form.teams.length" class="flex flex-wrap gap-1.5">
+            <span
+              v-for="t in form.teams"
+              :key="t.id"
+              class="inline-flex items-center gap-1.5 rounded bg-[hsl(var(--tac-amber)/0.12)] py-0.5 pl-1 pr-1 text-xs text-[hsl(var(--tac-amber))]"
+            >
+              <Avatar class="h-4 w-4 shrink-0 rounded-sm">
+                <AvatarImage
+                  v-if="teamAvatar(t)"
+                  :src="teamAvatar(t)!"
+                  :alt="t.name"
+                />
+                <AvatarFallback
+                  class="rounded-sm bg-[hsl(var(--tac-amber)/0.15)] text-[8px] text-[hsl(var(--tac-amber))]"
+                >
+                  {{ (t.short_name || t.name).slice(0, 2) }}
+                </AvatarFallback>
+              </Avatar>
+              <span class="max-w-[100px] truncate">{{ t.name }}</span>
               <button
                 type="button"
-                class="flex w-full items-center gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                class="text-[hsl(var(--tac-amber)/0.6)] transition-colors hover:text-[hsl(var(--tac-amber))]"
+                @click="removeTeam(t.id)"
               >
-                <Users class="h-3.5 w-3.5 shrink-0" />
-                <span class="flex-1 truncate text-left normal-case tracking-normal">
-                  {{ $t("pages.manage_matches.enter_team_name") }}
-                </span>
-                <ChevronDown class="h-3 w-3 shrink-0 opacity-50" />
+                <X class="h-3 w-3" />
               </button>
-            </TeamSearch>
-            <div v-if="form.teams.length" class="flex flex-wrap gap-1.5">
-              <span
-                v-for="t in form.teams"
-                :key="t.id"
-                class="inline-flex items-center gap-1.5 rounded bg-[hsl(var(--tac-amber)/0.12)] py-0.5 pl-1 pr-1 text-xs text-[hsl(var(--tac-amber))]"
-              >
-                <Avatar class="h-4 w-4 shrink-0 rounded-sm">
-                  <AvatarImage
-                    v-if="teamAvatar(t)"
-                    :src="teamAvatar(t)!"
-                    :alt="t.name"
-                  />
-                  <AvatarFallback
-                    class="rounded-sm bg-[hsl(var(--tac-amber)/0.15)] text-[8px] text-[hsl(var(--tac-amber))]"
-                  >
-                    {{ (t.short_name || t.name).slice(0, 2) }}
-                  </AvatarFallback>
-                </Avatar>
-                <span class="max-w-[100px] truncate">{{ t.name }}</span>
-                <button
-                  type="button"
-                  class="text-[hsl(var(--tac-amber)/0.6)] transition-colors hover:text-[hsl(var(--tac-amber))]"
-                  @click="removeTeam(t.id)"
-                >
-                  <X class="h-3 w-3" />
-                </button>
-              </span>
-            </div>
-          </div>
-
-          <!-- Players -->
-          <div class="space-y-1.5 border-t border-border/50 pt-3">
-            <span
-              class="block px-1 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
-            >
-              {{ $t("pages.matches.players") }}
             </span>
-            <PlayerSearch
-              :label="$t('player.search.placeholder')"
-              :exclude="form.players.map((p) => p.steam_id)"
-              @selected="addPlayer"
+          </div>
+        </div>
+
+        <!-- Players -->
+        <div class="space-y-1.5 border-t border-border/50 pt-3">
+          <span
+            class="block px-1 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
+          >
+            {{ $t("pages.matches.players") }}
+          </span>
+          <PlayerSearch
+            :label="$t('player.search.placeholder')"
+            :exclude="form.players.map((p) => p.steam_id)"
+            @selected="addPlayer"
+          >
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
             >
+              <User class="h-3.5 w-3.5 shrink-0" />
+              <span
+                class="flex-1 truncate text-left normal-case tracking-normal"
+              >
+                {{ $t("player.search.placeholder") }}
+              </span>
+              <ChevronDown class="h-3 w-3 shrink-0 opacity-50" />
+            </button>
+          </PlayerSearch>
+          <div v-if="form.players.length" class="flex flex-wrap gap-1.5">
+            <span
+              v-for="p in form.players"
+              :key="p.steam_id"
+              class="inline-flex items-center gap-1.5 rounded bg-[hsl(var(--tac-amber)/0.12)] py-0.5 pl-1 pr-1 text-xs text-[hsl(var(--tac-amber))]"
+            >
+              <Avatar class="h-4 w-4 shrink-0 rounded-full">
+                <AvatarImage
+                  v-if="playerAvatar(p)"
+                  :src="playerAvatar(p)!"
+                  :alt="p.name"
+                />
+                <AvatarFallback
+                  class="bg-[hsl(var(--tac-amber)/0.15)] text-[8px] text-[hsl(var(--tac-amber))]"
+                >
+                  {{ p.name.slice(0, 2) }}
+                </AvatarFallback>
+              </Avatar>
+              <span class="max-w-[100px] truncate">{{ p.name }}</span>
               <button
                 type="button"
-                class="flex w-full items-center gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                class="text-[hsl(var(--tac-amber)/0.6)] transition-colors hover:text-[hsl(var(--tac-amber))]"
+                @click="removePlayer(p.steam_id)"
               >
-                <User class="h-3.5 w-3.5 shrink-0" />
-                <span class="flex-1 truncate text-left normal-case tracking-normal">
-                  {{ $t("player.search.placeholder") }}
-                </span>
-                <ChevronDown class="h-3 w-3 shrink-0 opacity-50" />
+                <X class="h-3 w-3" />
               </button>
-            </PlayerSearch>
-            <div v-if="form.players.length" class="flex flex-wrap gap-1.5">
-              <span
-                v-for="p in form.players"
-                :key="p.steam_id"
-                class="inline-flex items-center gap-1.5 rounded bg-[hsl(var(--tac-amber)/0.12)] py-0.5 pl-1 pr-1 text-xs text-[hsl(var(--tac-amber))]"
-              >
-                <Avatar class="h-4 w-4 shrink-0 rounded-full">
-                  <AvatarImage
-                    v-if="playerAvatar(p)"
-                    :src="playerAvatar(p)!"
-                    :alt="p.name"
-                  />
-                  <AvatarFallback
-                    class="bg-[hsl(var(--tac-amber)/0.15)] text-[8px] text-[hsl(var(--tac-amber))]"
-                  >
-                    {{ p.name.slice(0, 2) }}
-                  </AvatarFallback>
-                </Avatar>
-                <span class="max-w-[100px] truncate">{{ p.name }}</span>
-                <button
-                  type="button"
-                  class="text-[hsl(var(--tac-amber)/0.6)] transition-colors hover:text-[hsl(var(--tac-amber))]"
-                  @click="removePlayer(p.steam_id)"
-                >
-                  <X class="h-3 w-3" />
-                </button>
-              </span>
-            </div>
-          </div>
-
-          <!-- Date window -->
-          <div class="space-y-1.5 border-t border-border/50 pt-3">
-            <span
-              class="block px-1 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
-            >
-              {{ $t("pages.matches.window") }}
             </span>
-            <Popover>
+          </div>
+        </div>
+
+        <!-- Date window -->
+        <div class="space-y-1.5 border-t border-border/50 pt-3">
+          <span
+            class="block px-1 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
+          >
+            {{ $t("pages.matches.window") }}
+          </span>
+          <Popover>
             <PopoverTrigger as-child>
               <button
                 type="button"
@@ -321,7 +322,9 @@ function optionRowClass(active: boolean) {
                 "
               >
                 <CalendarIcon class="h-3.5 w-3.5 shrink-0" />
-                <span class="flex-1 truncate text-left normal-case tracking-normal">
+                <span
+                  class="flex-1 truncate text-left normal-case tracking-normal"
+                >
                   {{
                     form.dateFrom || form.dateTo
                       ? $t("pages.matches.window")
@@ -385,70 +388,49 @@ function optionRowClass(active: boolean) {
                 </div>
               </div>
             </PopoverContent>
-            </Popover>
-          </div>
+          </Popover>
+        </div>
 
-          <!-- Options (shown directly, not behind a nested popover) -->
-          <div class="space-y-0.5 border-t border-border/50 pt-2">
-            <span
-              class="block px-2 pb-1 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
-            >
-              {{ $t("pages.matches.options") }}
-            </span>
-            <button
-              type="button"
-              @click="includeOutOfLineup = !includeOutOfLineup"
-              :class="optionRowClass(!includeOutOfLineup)"
-            >
-              <span>{{ $t("pages.matches.lineup_only") }}</span>
-              <Check
-                v-if="!includeOutOfLineup"
-                class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-              />
-            </button>
-            <button
-              type="button"
-              @click="includeExternal = !includeExternal"
-              :class="optionRowClass(includeExternal)"
-            >
-              <span>{{ $t("pages.matches.include_external") }}</span>
-              <Check
-                v-if="includeExternal"
-                class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-              />
-            </button>
-            <button
-              v-if="canManageMatches"
-              type="button"
-              @click="showOnlyMyMatches = !showOnlyMyMatches"
-              :class="optionRowClass(showOnlyMyMatches)"
-            >
-              <span>{{ $t("pages.manage_matches.only_my_matches") }}</span>
-              <Check
-                v-if="showOnlyMyMatches"
-                class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-              />
-            </button>
-            <div v-if="canManageMatches" class="relative mt-1.5">
-              <Hash
-                class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/50"
-              />
-              <Input
-                id="match-id-search"
-                :model-value="form.matchId"
-                @update:model-value="
-                  (value) => {
-                    form.matchId = String(value || '');
-                    onFilterChange();
-                  }
-                "
-                :placeholder="$t('pages.manage_matches.enter_match_id')"
-                class="h-8 pl-8 font-mono text-xs"
-              />
-            </div>
+        <!-- Options (shown directly, not behind a nested popover) -->
+        <div class="space-y-0.5 border-t border-border/50 pt-2">
+          <span
+            class="block px-2 pb-1 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground"
+          >
+            {{ $t("pages.matches.options") }}
+          </span>
+          <FilterToggle
+            :model-value="!includeOutOfLineup"
+            :label="$t('pages.matches.lineup_only')"
+            @update:model-value="(value) => (includeOutOfLineup = !value)"
+          />
+          <FilterToggle
+            v-model="includeExternal"
+            :label="$t('pages.matches.include_external')"
+          />
+          <FilterToggle
+            v-if="canManageMatches"
+            v-model="showOnlyMyMatches"
+            :label="$t('pages.manage_matches.only_my_matches')"
+          />
+          <div v-if="canManageMatches" class="relative mt-1.5">
+            <Hash
+              class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/50"
+            />
+            <Input
+              id="match-id-search"
+              :model-value="form.matchId"
+              @update:model-value="
+                (value) => {
+                  form.matchId = String(value || '');
+                  onFilterChange();
+                }
+              "
+              :placeholder="$t('pages.manage_matches.enter_match_id')"
+              class="h-8 pl-8 font-mono text-xs"
+            />
           </div>
-          </FilterMenu>
-
+        </div>
+      </FilterMenu>
     </FilterBar>
   </PageTransition>
 

--- a/pages/players/[id].vue
+++ b/pages/players/[id].vue
@@ -1649,7 +1649,7 @@ definePageMeta({
 
 const { isMobile } = useSidebar();
 const playerHeroClasses =
-  "relative flex min-w-0 flex-col rounded-lg border border-border px-6 py-5 [background:radial-gradient(120%_140%_at_0%_0%,hsl(var(--tac-amber)_/_0.06)_0%,transparent_45%),linear-gradient(180deg,hsl(var(--card)_/_0.5)_0%,hsl(var(--card)_/_0.2)_100%)] [backdrop-filter:blur(6px)] before:pointer-events-none before:absolute before:left-2 before:top-2 before:z-[1] before:h-[14px] before:w-[14px] before:border-l-2 before:border-t-2 before:border-[hsl(var(--tac-amber))] before:content-[''] after:pointer-events-none after:absolute after:bottom-2 after:right-2 after:z-[1] after:h-[14px] after:w-[14px] after:border-b-2 after:border-r-2 after:border-[hsl(var(--tac-amber))] after:content-[''] max-md:px-4 max-md:py-5";
+  "relative flex min-w-0 flex-col rounded-lg border border-border px-6 py-5 [background:radial-gradient(120%_140%_at_0%_0%,hsl(var(--tac-amber)_/_0.06)_0%,transparent_45%),linear-gradient(180deg,hsl(var(--card)_/_0.5)_0%,hsl(var(--card)_/_0.2)_100%)] [backdrop-filter:blur(6px)] max-md:px-4 max-md:py-5";
 const playerHeroBodyClasses =
   "flex flex-wrap items-center gap-5 max-md:items-start max-md:gap-4";
 const playerHeroInlineRoleChipClasses =

--- a/pages/players/index.vue
+++ b/pages/players/index.vue
@@ -15,6 +15,7 @@ import {
 } from "lucide-vue-next";
 import FilterBar from "~/components/common/FilterBar.vue";
 import FilterMenu from "~/components/common/FilterMenu.vue";
+import FilterToggle from "~/components/common/FilterToggle.vue";
 import { Card } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import {
@@ -107,264 +108,224 @@ import {
         :show-reset="hasActivePlayerFilters"
         @reset="resetFilters"
       >
-            <form @submit.prevent class="space-y-4">
-              <div class="grid gap-4 grid-cols-1 sm:grid-cols-2">
-                <!-- Elo range slider -->
-                <div class="space-y-3 sm:col-span-2">
-                  <div class="flex items-center justify-between">
-                    <Label>{{ $t("pages.players.elo_range") }}</Label>
-                    <span
-                      class="text-xs font-mono text-[hsl(var(--tac-amber))] tabular-nums"
-                    >
-                      {{ eloRange[0] }} — {{ eloRange[1] }}
-                    </span>
-                  </div>
-                  <Slider
-                    :model-value="eloRange"
-                    @update:model-value="onEloRangeChange"
-                    :min="eloSliderMin"
-                    :max="eloSliderMax"
-                    :step="100"
-                    class="py-2"
-                  />
-                </div>
-
-                <!-- Country multi-select -->
-                <div class="space-y-2">
-                  <Label for="countries-filter">{{
-                    $t("pages.players.filter_by_country")
-                  }}</Label>
-                  <Popover v-model:open="countryPopoverOpen">
-                    <PopoverTrigger as-child>
-                      <Button
-                        id="countries-filter"
-                        role="combobox"
-                        variant="outline"
-                        class="w-full justify-between"
-                      >
-                        <span
-                          v-if="
-                            form.values.countries &&
-                            form.values.countries.length > 0
-                          "
-                          class="text-sm"
-                        >
-                          {{ form.values.countries.length }}
-                          {{ $t("pages.players.countries_selected") }}
-                        </span>
-                        <span v-else class="text-muted-foreground">
-                          {{ $t("pages.players.select_country") }}
-                        </span>
-                        <ChevronsUpDown
-                          class="ml-2 h-4 w-4 shrink-0 opacity-50"
-                        />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent class="w-full p-0">
-                      <Command class="w-[300px]">
-                        <CommandInput
-                          :placeholder="$t('pages.players.search_country')"
-                        />
-                        <CommandEmpty>{{
-                          $t("pages.players.no_country_found")
-                        }}</CommandEmpty>
-                        <CommandList>
-                          <CommandGroup>
-                            <CommandItem
-                              v-for="country in sortedCountries"
-                              :key="country.id"
-                              :value="country.name"
-                              @select="
-                                () => {
-                                  toggleCountry(country.id);
-                                }
-                              "
-                            >
-                              <div class="flex items-center gap-2 w-full">
-                                <TimezoneFlag :country="country.id" />
-                                <span class="truncate">{{ country.name }}</span>
-                              </div>
-                              <Check
-                                :class="[
-                                  'ml-auto h-4 w-4 flex-shrink-0',
-                                  form.values.countries?.includes(country.id)
-                                    ? 'opacity-100'
-                                    : 'opacity-0',
-                                ]"
-                              />
-                            </CommandItem>
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
-                </div>
-
-                <!-- Privilege/Role multi-select (admin only) -->
-                <div v-if="canViewAdditionalDetails" class="space-y-2">
-                  <Label for="roles-filter">{{
-                    $t("pages.players.filter_by_privilege")
-                  }}</Label>
-                  <Popover v-model:open="rolePopoverOpen">
-                    <PopoverTrigger as-child>
-                      <Button
-                        id="roles-filter"
-                        role="combobox"
-                        variant="outline"
-                        class="w-full justify-between"
-                      >
-                        <span
-                          v-if="
-                            form.values.roles && form.values.roles.length > 0
-                          "
-                          class="text-sm"
-                        >
-                          {{ form.values.roles.length }}
-                          {{ $t("pages.players.privileges_selected") }}
-                        </span>
-                        <span v-else class="text-muted-foreground">
-                          {{ $t("pages.players.select_privileges") }}
-                        </span>
-                        <ChevronsUpDown
-                          class="ml-2 h-4 w-4 shrink-0 opacity-50"
-                        />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent class="w-full p-0">
-                      <Command class="w-[240px]">
-                        <CommandList>
-                          <CommandGroup>
-                            <CommandItem
-                              v-for="role in availableRoles"
-                              :key="role.value"
-                              :value="role.display"
-                              @select="() => toggleRole(role.value)"
-                            >
-                              <span>{{ role.display }}</span>
-                              <Check
-                                :class="[
-                                  'ml-auto h-4 w-4 flex-shrink-0',
-                                  form.values.roles?.includes(role.value)
-                                    ? 'opacity-100'
-                                    : 'opacity-0',
-                                ]"
-                              />
-                            </CommandItem>
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
-                </div>
-
-                <!-- Min sanctions (admin only) -->
-                <div v-if="canViewAdditionalDetails" class="space-y-2">
-                  <Label for="sanctions-min">{{
-                    $t("pages.players.min_sanctions")
-                  }}</Label>
-                  <Input
-                    id="sanctions-min"
-                    type="number"
-                    :model-value="form.values.sanctionsMin?.toString() || ''"
-                    @update:model-value="
-                      (value) => {
-                        form.setFieldValue(
-                          'sanctionsMin',
-                          value ? parseInt(value as string) || null : null,
-                        );
-                        onFilterChange();
-                      }
-                    "
-                    :placeholder="$t('pages.players.min_sanctions')"
-                    min="0"
-                  />
-                </div>
-              </div>
-
-              <!-- Boolean toggles -->
-              <div class="space-y-0.5 border-t border-border/50 pt-2">
-                <button
-                  type="button"
-                  class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50"
-                  :class="
-                    onlyPlayedMatches
-                      ? 'text-[hsl(var(--tac-amber))]'
-                      : 'text-foreground/90'
-                  "
-                  @click="onlyPlayedMatches = !onlyPlayedMatches"
+        <form @submit.prevent class="space-y-4">
+          <div class="grid gap-4 grid-cols-1 sm:grid-cols-2">
+            <!-- Elo range slider -->
+            <div class="space-y-3 sm:col-span-2">
+              <div class="flex items-center justify-between">
+                <Label>{{ $t("pages.players.elo_range") }}</Label>
+                <span
+                  class="text-xs font-mono text-[hsl(var(--tac-amber))] tabular-nums"
                 >
-                  <span>{{ $t("pages.players.played_matches") }}</span>
-                  <Check
-                    v-if="onlyPlayedMatches"
-                    class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-                  />
-                </button>
-
-                <template v-if="canViewAdditionalDetails">
-                  <button
-                    type="button"
-                    class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50"
-                    :class="
-                      form.values.isBanned ? 'text-red-500' : 'text-foreground/90'
-                    "
-                    @click="
-                      () => {
-                        form.setFieldValue('isBanned', !form.values.isBanned);
-                        onFilterChange();
-                      }
-                    "
-                  >
-                    <span>{{ $t("pages.players.is_banned") }}</span>
-                    <Check
-                      v-if="form.values.isBanned"
-                      class="h-3.5 w-3.5 text-red-500"
-                    />
-                  </button>
-                  <button
-                    type="button"
-                    class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50"
-                    :class="
-                      form.values.isGagged
-                        ? 'text-yellow-500'
-                        : 'text-foreground/90'
-                    "
-                    @click="
-                      () => {
-                        form.setFieldValue('isGagged', !form.values.isGagged);
-                        onFilterChange();
-                      }
-                    "
-                  >
-                    <span>{{ $t("pages.players.is_gagged") }}</span>
-                    <Check
-                      v-if="form.values.isGagged"
-                      class="h-3.5 w-3.5 text-yellow-500"
-                    />
-                  </button>
-                  <button
-                    type="button"
-                    class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50"
-                    :class="
-                      form.values.isMuted ? 'text-yellow-500' : 'text-foreground/90'
-                    "
-                    @click="
-                      () => {
-                        form.setFieldValue('isMuted', !form.values.isMuted);
-                        onFilterChange();
-                      }
-                    "
-                  >
-                    <span>{{ $t("pages.players.is_muted") }}</span>
-                    <Check
-                      v-if="form.values.isMuted"
-                      class="h-3.5 w-3.5 text-yellow-500"
-                    />
-                  </button>
-                </template>
+                  {{ eloRange[0] }} — {{ eloRange[1] }}
+                </span>
               </div>
-            </form>
-      </FilterMenu>
+              <Slider
+                :model-value="eloRange"
+                @update:model-value="onEloRangeChange"
+                :min="eloSliderMin"
+                :max="eloSliderMax"
+                :step="100"
+                class="py-2"
+              />
+            </div>
 
+            <!-- Country multi-select -->
+            <div class="space-y-2">
+              <Label for="countries-filter">{{
+                $t("pages.players.filter_by_country")
+              }}</Label>
+              <Popover v-model:open="countryPopoverOpen">
+                <PopoverTrigger as-child>
+                  <Button
+                    id="countries-filter"
+                    role="combobox"
+                    variant="outline"
+                    class="w-full justify-between"
+                  >
+                    <span
+                      v-if="
+                        form.values.countries &&
+                        form.values.countries.length > 0
+                      "
+                      class="text-sm"
+                    >
+                      {{ form.values.countries.length }}
+                      {{ $t("pages.players.countries_selected") }}
+                    </span>
+                    <span v-else class="text-muted-foreground">
+                      {{ $t("pages.players.select_country") }}
+                    </span>
+                    <ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent class="w-full p-0">
+                  <Command class="w-[300px]">
+                    <CommandInput
+                      :placeholder="$t('pages.players.search_country')"
+                    />
+                    <CommandEmpty>{{
+                      $t("pages.players.no_country_found")
+                    }}</CommandEmpty>
+                    <CommandList>
+                      <CommandGroup>
+                        <CommandItem
+                          v-for="country in sortedCountries"
+                          :key="country.id"
+                          :value="country.name"
+                          @select="
+                            () => {
+                              toggleCountry(country.id);
+                            }
+                          "
+                        >
+                          <div class="flex items-center gap-2 w-full">
+                            <TimezoneFlag :country="country.id" />
+                            <span class="truncate">{{ country.name }}</span>
+                          </div>
+                          <Check
+                            :class="[
+                              'ml-auto h-4 w-4 flex-shrink-0',
+                              form.values.countries?.includes(country.id)
+                                ? 'opacity-100'
+                                : 'opacity-0',
+                            ]"
+                          />
+                        </CommandItem>
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
+
+            <!-- Privilege/Role multi-select (admin only) -->
+            <div v-if="canViewAdditionalDetails" class="space-y-2">
+              <Label for="roles-filter">{{
+                $t("pages.players.filter_by_privilege")
+              }}</Label>
+              <Popover v-model:open="rolePopoverOpen">
+                <PopoverTrigger as-child>
+                  <Button
+                    id="roles-filter"
+                    role="combobox"
+                    variant="outline"
+                    class="w-full justify-between"
+                  >
+                    <span
+                      v-if="form.values.roles && form.values.roles.length > 0"
+                      class="text-sm"
+                    >
+                      {{ form.values.roles.length }}
+                      {{ $t("pages.players.privileges_selected") }}
+                    </span>
+                    <span v-else class="text-muted-foreground">
+                      {{ $t("pages.players.select_privileges") }}
+                    </span>
+                    <ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent class="w-full p-0">
+                  <Command class="w-[240px]">
+                    <CommandList>
+                      <CommandGroup>
+                        <CommandItem
+                          v-for="role in availableRoles"
+                          :key="role.value"
+                          :value="role.display"
+                          @select="() => toggleRole(role.value)"
+                        >
+                          <span>{{ role.display }}</span>
+                          <Check
+                            :class="[
+                              'ml-auto h-4 w-4 flex-shrink-0',
+                              form.values.roles?.includes(role.value)
+                                ? 'opacity-100'
+                                : 'opacity-0',
+                            ]"
+                          />
+                        </CommandItem>
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
+
+            <!-- Min sanctions (admin only) -->
+            <div v-if="canViewAdditionalDetails" class="space-y-2">
+              <Label for="sanctions-min">{{
+                $t("pages.players.min_sanctions")
+              }}</Label>
+              <Input
+                id="sanctions-min"
+                type="number"
+                :model-value="form.values.sanctionsMin?.toString() || ''"
+                @update:model-value="
+                  (value) => {
+                    form.setFieldValue(
+                      'sanctionsMin',
+                      value ? parseInt(value as string) || null : null,
+                    );
+                    onFilterChange();
+                  }
+                "
+                :placeholder="$t('pages.players.min_sanctions')"
+                min="0"
+              />
+            </div>
+          </div>
+
+          <!-- Boolean toggles -->
+          <div class="space-y-0.5 border-t border-border/50 pt-2">
+            <FilterToggle
+              v-model="onlyPlayedMatches"
+              :label="$t('pages.players.played_matches')"
+            />
+            <FilterToggle v-model="onlyOnline" :label="$t('common.online')" />
+            <FilterToggle
+              v-model="onlyRegistered"
+              :label="$t('search.registered')"
+            />
+
+            <template v-if="canViewAdditionalDetails">
+              <FilterToggle
+                :model-value="!!form.values.isBanned"
+                :label="$t('pages.players.is_banned')"
+                tone="danger"
+                @update:model-value="
+                  (value) => {
+                    form.setFieldValue('isBanned', value);
+                    onFilterChange();
+                  }
+                "
+              />
+              <FilterToggle
+                :model-value="!!form.values.isGagged"
+                :label="$t('pages.players.is_gagged')"
+                tone="warning"
+                @update:model-value="
+                  (value) => {
+                    form.setFieldValue('isGagged', value);
+                    onFilterChange();
+                  }
+                "
+              />
+              <FilterToggle
+                :model-value="!!form.values.isMuted"
+                :label="$t('pages.players.is_muted')"
+                tone="warning"
+                @update:model-value="
+                  (value) => {
+                    form.setFieldValue('isMuted', value);
+                    onFilterChange();
+                  }
+                "
+              />
+            </template>
+          </div>
+        </form>
+      </FilterMenu>
     </FilterBar>
   </PageTransition>
 
@@ -545,6 +506,8 @@ export default {
       sortDirection: this.loadFiltersFromStorage().sortDirection || "asc",
       onlyPlayedMatches:
         this.loadFiltersFromStorage().onlyPlayedMatches || false,
+      onlyOnline: this.loadFiltersFromStorage().onlyOnline || false,
+      onlyRegistered: this.loadFiltersFromStorage().onlyRegistered || false,
       countryPopoverOpen: false,
       rolePopoverOpen: false,
       filtersPopoverOpen: false,
@@ -605,6 +568,9 @@ export default {
     },
     canViewAdditionalDetails() {
       return useAuthStore().isRoleAbove(e_player_roles_enum.match_organizer);
+    },
+    onlinePlayerSteamIds() {
+      return useMatchmakingStore().onlinePlayerSteamIds as string[];
     },
     eloRange() {
       return [
@@ -699,6 +665,26 @@ export default {
           value: "yes",
           clear: () => {
             this.onlyPlayedMatches = false;
+          },
+        });
+      }
+      if (this.onlyOnline) {
+        chips.push({
+          id: "online",
+          label: this.$t("common.online"),
+          value: "yes",
+          clear: () => {
+            this.onlyOnline = false;
+          },
+        });
+      }
+      if (this.onlyRegistered) {
+        chips.push({
+          id: "registered",
+          label: this.$t("search.registered"),
+          value: "yes",
+          clear: () => {
+            this.onlyRegistered = false;
           },
         });
       }
@@ -806,6 +792,21 @@ export default {
       this.page = 1;
       this.onFilterChange();
     },
+    onlyOnline() {
+      this.page = 1;
+      this.onFilterChange();
+    },
+    onlyRegistered() {
+      this.page = 1;
+      this.onFilterChange();
+    },
+    // Presence is pushed in live, so a player going on or offline has to
+    // re-run the search while the filter is on.
+    onlinePlayerSteamIds() {
+      if (this.onlyOnline) {
+        this.onFilterChange();
+      }
+    },
     sortField() {
       this.page = 1;
       this.onFilterChange();
@@ -840,6 +841,8 @@ export default {
         isMuted: false,
       });
       this.onlyPlayedMatches = false;
+      this.onlyOnline = false;
+      this.onlyRegistered = false;
       this.sortField = "name";
       this.sortDirection = "asc";
       this.page = 1;
@@ -897,6 +900,8 @@ export default {
             isGagged: this.form.values.isGagged,
             isMuted: this.form.values.isMuted,
             onlyPlayedMatches: this.onlyPlayedMatches,
+            onlyOnline: this.onlyOnline,
+            onlyRegistered: this.onlyRegistered,
             sortField: this.sortField,
             sortDirection: this.sortDirection,
             perPage: this.perPage,
@@ -1027,6 +1032,10 @@ export default {
                 ? this.form.values.isMuted
                 : undefined,
             only_played_matches: this.onlyPlayedMatches,
+            registeredOnly: this.onlyRegistered || undefined,
+            online_steam_ids: this.onlyOnline
+              ? this.onlinePlayerSteamIds
+              : undefined,
             elo_track: "season",
             sort_by: this.getSortBy(),
           },

--- a/pages/players/index.vue
+++ b/pages/players/index.vue
@@ -572,6 +572,9 @@ export default {
     onlinePlayerSteamIds() {
       return useMatchmakingStore().onlinePlayerSteamIds as string[];
     },
+    presenceLoaded() {
+      return useMatchmakingStore().presenceLoaded as boolean;
+    },
     eloRange() {
       return [
         this.form.values.eloMin ?? this.eloSliderMin,
@@ -801,13 +804,27 @@ export default {
       this.onFilterChange();
     },
     // Presence is pushed in live, so a player going on or offline has to
-    // re-run the search while the filter is on.
+    // re-run the search while the filter is on. Deliberately not
+    // onFilterChange(): that resets to page 1, and someone anywhere on the
+    // instance connecting would yank you back to the top of the list.
     onlinePlayerSteamIds() {
       if (this.onlyOnline) {
-        this.onFilterChange();
+        this.queueSearch();
       }
     },
-    sortField() {
+    // The first presence payload is what makes the filter applicable at all.
+    presenceLoaded() {
+      if (this.onlyOnline) {
+        this.queueSearch();
+      }
+    },
+    sortField(value: string) {
+      // The server forces the registered filter for this sort -- an unregistered
+      // player has no sign-in to order by. Reflect it in the toggle and chip
+      // instead of quietly dropping people while the UI claims no filter.
+      if (value === "last_sign_in_at") {
+        this.onlyRegistered = true;
+      }
       this.page = 1;
       this.onFilterChange();
     },
@@ -1033,9 +1050,13 @@ export default {
                 : undefined,
             only_played_matches: this.onlyPlayedMatches,
             registeredOnly: this.onlyRegistered || undefined,
-            online_steam_ids: this.onlyOnline
-              ? this.onlinePlayerSteamIds
-              : undefined,
+            // Held back until presence has actually arrived. Sending an empty
+            // roster means "nobody is online" and returns nothing, which on a
+            // reload is indistinguishable from a broken filter.
+            online_steam_ids:
+              this.onlyOnline && this.presenceLoaded
+                ? this.onlinePlayerSteamIds
+                : undefined,
             elo_track: "season",
             sort_by: this.getSortBy(),
           },

--- a/pages/scrims/index.vue
+++ b/pages/scrims/index.vue
@@ -225,6 +225,8 @@ export default {
                 avatar_url: true,
                 ranks: {
                   avg_elo: true,
+                  avg_wingman_elo: true,
+                  avg_duel_elo: true,
                   min_elo: true,
                   max_elo: true,
                   avg_faceit_level: true,

--- a/pages/teams/[id].vue
+++ b/pages/teams/[id].vue
@@ -494,6 +494,8 @@ export default {
               can_manage_scrims: true,
               ranks: {
                 avg_elo: true,
+                avg_wingman_elo: true,
+                avg_duel_elo: true,
                 min_elo: true,
                 max_elo: true,
                 avg_faceit_level: true,

--- a/pages/teams/index.vue
+++ b/pages/teams/index.vue
@@ -8,7 +8,6 @@ import {
   Swords,
   SlidersHorizontal,
   ChevronDown,
-  Check,
 } from "lucide-vue-next";
 import {
   InputGroup,
@@ -22,6 +21,7 @@ import {
 } from "~/components/ui/popover";
 import FilterBar from "~/components/common/FilterBar.vue";
 import FilterMenu from "~/components/common/FilterMenu.vue";
+import FilterToggle from "~/components/common/FilterToggle.vue";
 import TeamsTable from "~/components/TeamsTable.vue";
 import TacticalPageHeader from "~/components/TacticalPageHeader.vue";
 import Pagination from "@/components/Pagination.vue";
@@ -112,42 +112,20 @@ import {
         content-class="w-64 space-y-0.5 p-2"
         @reset="resetTeamFilters"
       >
-        <button
-          type="button"
-          @click="toggleTournamentWinners"
-          class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50"
-          :class="
-            tournamentWinnersOnly
-              ? 'text-[hsl(var(--tac-amber))]'
-              : 'text-foreground/90'
-          "
+        <FilterToggle
+          :model-value="tournamentWinnersOnly"
+          :label="$t('team.search.tournament_winners')"
+          @update:model-value="toggleTournamentWinners"
         >
-          <span class="flex items-center gap-2">
-            <Trophy class="h-3.5 w-3.5" />
-            {{ $t("team.search.tournament_winners") }}
-          </span>
-          <Check
-            v-if="tournamentWinnersOnly"
-            class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-          />
-        </button>
-        <button
-          type="button"
-          @click="toggleScrimsOnly"
-          class="flex w-full items-center justify-between rounded px-2 py-1.5 text-xs transition-colors hover:bg-muted/50"
-          :class="
-            scrimsOnly ? 'text-[hsl(var(--tac-amber))]' : 'text-foreground/90'
-          "
+          <template #icon><Trophy class="h-3.5 w-3.5" /></template>
+        </FilterToggle>
+        <FilterToggle
+          :model-value="scrimsOnly"
+          :label="$t('team.search.scrims_only')"
+          @update:model-value="toggleScrimsOnly"
         >
-          <span class="flex items-center gap-2">
-            <Swords class="h-3.5 w-3.5" />
-            {{ $t("team.search.scrims_only") }}
-          </span>
-          <Check
-            v-if="scrimsOnly"
-            class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-          />
-        </button>
+          <template #icon><Swords class="h-3.5 w-3.5" /></template>
+        </FilterToggle>
       </FilterMenu>
     </FilterBar>
   </PageTransition>

--- a/pages/tournaments/manage.vue
+++ b/pages/tournaments/manage.vue
@@ -14,6 +14,7 @@ import {
 import TournamentFeatureCard from "~/components/tournament/TournamentFeatureCard.vue";
 import FilterBar from "~/components/common/FilterBar.vue";
 import FilterMenu from "~/components/common/FilterMenu.vue";
+import FilterToggle from "~/components/common/FilterToggle.vue";
 import Pagination from "~/components/Pagination.vue";
 import { Button } from "~/components/ui/button";
 import {
@@ -69,10 +70,10 @@ function optionRowClass(active: boolean) {
         <button
           type="button"
           :class="[
-          tacticalCtaButtonClasses,
-          tacticalHeaderActionClasses,
-          'max-md:aspect-square max-md:!px-0',
-        ]"
+            tacticalCtaButtonClasses,
+            tacticalHeaderActionClasses,
+            'max-md:aspect-square max-md:!px-0',
+          ]"
           :title="$t('pages.tournaments.create')"
           @click="navigateTo('/tournaments/create')"
         >
@@ -102,7 +103,10 @@ function optionRowClass(active: boolean) {
           >
             <Activity class="h-3.5 w-3.5" />
             {{ $t("common.status") }}
-            <span v-if="form.values.statuses?.length" :class="filterBadgeClasses">
+            <span
+              v-if="form.values.statuses?.length"
+              :class="filterBadgeClasses"
+            >
               {{ form.values.statuses.length }}
             </span>
             <ChevronDown class="h-3 w-3 opacity-50" />
@@ -195,17 +199,10 @@ function optionRowClass(active: boolean) {
           >
             {{ $t("common.options") }}
           </span>
-          <button
-            type="button"
-            @click="showOnlyMyTournaments = !showOnlyMyTournaments"
-            :class="optionRowClass(showOnlyMyTournaments)"
-          >
-            <span>{{ $t("pages.manage_tournaments.only_my_tournaments") }}</span>
-            <Check
-              v-if="showOnlyMyTournaments"
-              class="h-3.5 w-3.5 text-[hsl(var(--tac-amber))]"
-            />
-          </button>
+          <FilterToggle
+            v-model="showOnlyMyTournaments"
+            :label="$t('pages.manage_tournaments.only_my_tournaments')"
+          />
         </div>
       </FilterMenu>
     </FilterBar>

--- a/server/api/players-search.post.ts
+++ b/server/api/players-search.post.ts
@@ -100,6 +100,22 @@ export default defineEventHandler(async (event) => {
     filterBy.push(`is_registered:=true`);
   }
 
+  // Presence is live app state, not something the index knows, so the caller
+  // sends the roster it can see and results are constrained to it.
+  const onlineSteamIds = Array.isArray(body.online_steam_ids)
+    ? body.online_steam_ids.filter((id: unknown) => /^[0-9]+$/.test(String(id)))
+    : null;
+
+  // Nobody online has to mean no results. Falling through to an unfiltered
+  // search would return everyone, which reads as "the filter is broken".
+  if (onlineSteamIds && onlineSteamIds.length === 0) {
+    return { found: 0, hits: [] };
+  }
+
+  if (onlineSteamIds) {
+    filterBy.push(`steam_id:[${onlineSteamIds.join(",")}]`);
+  }
+
   // Filter by team
   if (body.teamId) {
     filterBy.push(`teams:${body.teamId}`);
@@ -179,10 +195,13 @@ export default defineEventHandler(async (event) => {
     return results;
   }
 
-  // Only do Steam API search if we have a query and no results found
+  // Only do Steam API search if we have a query and no results found. A search
+  // scoped to who is online can't be satisfied by a Steam account we have never
+  // seen, so that path stays out of it.
   if (
     process.env.STEAM_API_KEY &&
     !body.teamId &&
+    !onlineSteamIds &&
     query &&
     results.found === 0
   ) {

--- a/server/api/players-search.post.ts
+++ b/server/api/players-search.post.ts
@@ -93,7 +93,11 @@ export default defineEventHandler(async (event) => {
       : `${sortField}:${sortDirection}`;
 
   if (body.registeredOnly || sortField === "last_sign_in_at") {
-    filterBy.push(`last_sign_in_at:!~~`);
+    // Uses the dedicated bool rather than `last_sign_in_at:!~~`. That was a
+    // string-inequality filter against a timestamp, and timestamps contain
+    // ":", "+" and "." -- so it matched unreliably and silently dropped
+    // registered players from results that asked for registered players only.
+    filterBy.push(`is_registered:=true`);
   }
 
   // Filter by team

--- a/server/api/players-search.post.ts
+++ b/server/api/players-search.post.ts
@@ -93,11 +93,13 @@ export default defineEventHandler(async (event) => {
       : `${sortField}:${sortDirection}`;
 
   if (body.registeredOnly || sortField === "last_sign_in_at") {
-    // Uses the dedicated bool rather than `last_sign_in_at:!~~`. That was a
-    // string-inequality filter against a timestamp, and timestamps contain
-    // ":", "+" and "." -- so it matched unreliably and silently dropped
-    // registered players from results that asked for registered players only.
-    filterBy.push(`is_registered:=true`);
+    // Both spellings, because `is_registered` is an optional field added with
+    // this change: until the full re-index finishes, no existing document
+    // carries it and matching on it alone returns nothing at all. The
+    // `last_sign_in_at` sentinel ("~~" for never signed in) is what every
+    // already-indexed document has, so it covers the gap and drops out
+    // naturally once every document has been rewritten.
+    filterBy.push(`(is_registered:=true || last_sign_in_at:!~~)`);
   }
 
   // Presence is live app state, not something the index knows, so the caller
@@ -186,10 +188,17 @@ export default defineEventHandler(async (event) => {
     ...(body.per_page ? { per_page: body.per_page } : {}),
   };
 
-  const results = await client
-    .collections("players")
-    .documents()
-    .search(searchParams);
+  // documents().search() is a GET with every param in the query string, so a
+  // presence filter listing hundreds of steam ids can overrun the request line
+  // and come back as a hard error. multiSearch sends the same search as a POST
+  // body, which has no such ceiling.
+  const results = onlineSteamIds
+    ? (
+        await client.multiSearch.perform<any[]>({
+          searches: [{ collection: "players", ...searchParams }],
+        })
+      ).results[0]
+    : await client.collections("players").documents().search(searchParams);
 
   if (body.registeredOnly) {
     return results;

--- a/stores/MatchmakingStore.ts
+++ b/stores/MatchmakingStore.ts
@@ -38,6 +38,11 @@ export const useMatchmakingStore = defineStore("matchmaking", () => {
   const playersOnline = ref([]);
   const onlinePlayerSteamIds = ref<string[]>([]);
 
+  // Whether the players-online event has landed at least once. Before it does,
+  // an empty roster is indistinguishable from nobody being online, and callers
+  // that filter on presence have to tell those two apart.
+  const presenceLoaded = ref(false);
+
   const joinedMatchmakingQueues = ref<{
     details?: {
       totalInQueue: number;
@@ -260,11 +265,17 @@ export const useMatchmakingStore = defineStore("matchmaking", () => {
   // Steam friends who have never signed in here still land in the list, since
   // being Steam friends is enough to be added. Off by default so nobody
   // silently loses people they expect to see.
+  //
+  // Deliberately NOT applied to onlineFriends/offlineFriends below: those feed
+  // the right-hub badge and the social panel, neither of which offers this
+  // toggle, so filtering there made a count drop with nothing on screen to
+  // explain it. The lobby list that owns the toggle applies it itself.
   const registeredFriendsOnly = ref(false);
 
-  const isListedFriend = (friend: any) =>
-    friend.status !== "Pending" &&
-    (!registeredFriendsOnly.value || friend.player?.is_registered !== false);
+  const isRegisteredFriend = (friend: any) =>
+    friend.player?.is_registered !== false;
+
+  const isListedFriend = (friend: any) => friend.status !== "Pending";
 
   const onlineFriends = computed(() => {
     return friends.value?.filter(
@@ -631,11 +642,13 @@ export const useMatchmakingStore = defineStore("matchmaking", () => {
     onlineFriends,
     offlineFriends,
     registeredFriendsOnly,
+    isRegisteredFriend,
     lobbies,
     currentLobby,
     regionStats,
     playersOnline,
     onlinePlayerSteamIds,
+    presenceLoaded,
     joinedMatchmakingQueues,
 
     checkLatenies,

--- a/stores/MatchmakingStore.ts
+++ b/stores/MatchmakingStore.ts
@@ -111,6 +111,7 @@ export const useMatchmakingStore = defineStore("matchmaking", () => {
             presence_updated_at: true,
             player: {
               steam_id: true,
+              is_registered: true,
               is_in_lobby: true,
               is_in_another_match: true,
               is_in_draft: true,
@@ -256,15 +257,24 @@ export const useMatchmakingStore = defineStore("matchmaking", () => {
     onlinePlayerSteamIds.value.includes(friend.steam_id) ||
     isInCs2(friend.last_presence_state);
 
+  // Steam friends who have never signed in here still land in the list, since
+  // being Steam friends is enough to be added. Off by default so nobody
+  // silently loses people they expect to see.
+  const registeredFriendsOnly = ref(false);
+
+  const isListedFriend = (friend: any) =>
+    friend.status !== "Pending" &&
+    (!registeredFriendsOnly.value || friend.player?.is_registered !== false);
+
   const onlineFriends = computed(() => {
     return friends.value?.filter(
-      (friend: any) => friend.status !== "Pending" && isActiveFriend(friend),
+      (friend: any) => isListedFriend(friend) && isActiveFriend(friend),
     );
   });
 
   const offlineFriends = computed(() => {
     return friends.value?.filter(
-      (friend: any) => friend.status !== "Pending" && !isActiveFriend(friend),
+      (friend: any) => isListedFriend(friend) && !isActiveFriend(friend),
     );
   });
 
@@ -620,6 +630,7 @@ export const useMatchmakingStore = defineStore("matchmaking", () => {
     friends,
     onlineFriends,
     offlineFriends,
+    registeredFriendsOnly,
     lobbies,
     currentLobby,
     regionStats,

--- a/stores/SearchStore.ts
+++ b/stores/SearchStore.ts
@@ -11,6 +11,12 @@ export const useSearchStore = defineStore("searchStore", () => {
     localStorage.getItem("playerSearchOnlineOnly") !== "false",
   );
 
+  // Off by default: searching an unregistered Steam account is the point of
+  // the search, this only narrows it to people who have signed in here.
+  const registeredOnly = ref<boolean>(
+    localStorage.getItem("playerSearchRegisteredOnly") === "true",
+  );
+
   const onlinePlayers = computed(() => {
     const onlineIds = new Set(
       matchMakingStore.onlinePlayerSteamIds as string[],
@@ -67,6 +73,7 @@ export const useSearchStore = defineStore("searchStore", () => {
 
   return {
     onlineOnly,
+    registeredOnly,
     // Returns every match; the caller windows it (PlayerSearch pages through
     // this list the same way it pages the Typesense results).
     search: (query: string, exclude: string[]) => {

--- a/web-sockets/Socket.ts
+++ b/web-sockets/Socket.ts
@@ -374,6 +374,7 @@ socket.listen("matchmaking:region-stats", (data) => {
 
 socket.listen("players-online", (onlinePlayerSteamIds) => {
   useMatchmakingStore().onlinePlayerSteamIds = onlinePlayerSteamIds;
+  useMatchmakingStore().presenceLoaded = true;
 });
 
 socket.listen("matchmaking:error", (data: { message: string }) => {


### PR DESCRIPTION
Surfaces the API changes that land alongside this, plus a few fixes to things that were already broken.

Pairs with the API and game-server branches of the same name.

## Leaderboard

Adds the **source filter** the API now supports — matchmaking, tournament, league, or overall. `$source` is threaded through both queries and driven by a Select above the table.

Also renders `player_custom_avatar_url`, so custom avatars show up on the board instead of falling back to the Steam avatar.

## Bans and sanctions

- **Matchmaking showed that you were banned but not until when.** Now shows the expiry, using the new `banned_until` field.
- **`TimeAgo` gained a `countdown` prop.** A future timestamp previously rendered as a negative time-ago ("-3 minutes ago"). In countdown mode it counts down properly.
- **Player sanction entries link to the match they came from.** Sanctions with no match attached fall back to plain text rather than rendering a dead link.

## Registered-only toggles

Both player search and the friends list get a registered-only toggle.

The API change here is deliberate: unregistered players are now *indexed and badged* rather than filtered out of search entirely. Searching any Steam account still works — the UI just knows whether the result has actually signed in, and shows a "Not registered" badge when it has not. The toggle is for when you want to skip them.

## Match page

- **Selecting a match winner** wrote directly to `update_matches_by_pk`, which set the winner without reconciling the bracket. It now goes through the `setMatchWinner` action.
- Shows demo processing progress, using `demo_processing_started_at` with the new countdown mode.
- Adds the team chat lobby, keyed on `myLineupId`.

## On typechecking

This repo has a large number of pre-existing `vue-tsc` errors — `pages/matches/[id]/index.vue` alone has 88 `type 'never'` errors that predate this branch. I checked these changes by diffing type errors against a baseline and looking only at ones landing on changed lines. Worth knowing if you run `nuxt typecheck` and are alarmed by the total.

Two fixes came out of that: `formatBanExpiry` takes `unknown` rather than `string | Date`, because a zeus `timestamptz` does not arrive as either.
